### PR TITLE
Fix testbench version to match targeted Laravel version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "illuminate/support": "^7.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^4.0",
+        "orchestra/testbench": "^5.0",
         "phpunit/phpunit": "^8.0"
     },
     "autoload": {


### PR DESCRIPTION
Since you're targeting Laravel 7, the Testbench version needs to be 5. This PR resolves the dependency conflict in composer.json