### PR TITLE
Fix NotificationSent event is fired before NotificationSending

### DIFF
--- a/src/RateLimitChannelManager.php
+++ b/src/RateLimitChannelManager.php
@@ -10,8 +10,8 @@ class RateLimitChannelManager extends ChannelManager
     public function send($notifiables, $notification)
     {
         if ($this->checkRateLimit($notifiables, $notification)) {
-            event(new NotificationSent($notifiables, $notification, $this->channel()));
             parent::send($notifiables, $notification);
+            event(new NotificationSent($notifiables, $notification, $this->channel()));
         }
     }
 

--- a/src/RateLimitChannelManager.php
+++ b/src/RateLimitChannelManager.php
@@ -11,7 +11,6 @@ class RateLimitChannelManager extends ChannelManager
     {
         if ($this->checkRateLimit($notifiables, $notification)) {
             parent::send($notifiables, $notification);
-            event(new NotificationSent($notifiables, $notification, $this->channel()));
         }
     }
 

--- a/src/RateLimitChannelManager.php
+++ b/src/RateLimitChannelManager.php
@@ -3,7 +3,6 @@
 namespace Jamesmills\LaravelNotificationRateLimit;
 
 use Illuminate\Notifications\ChannelManager;
-use Illuminate\Notifications\Events\NotificationSent;
 
 class RateLimitChannelManager extends ChannelManager
 {


### PR DESCRIPTION
The issue:
While using clockwork, trying to send a notification to a user the notification is not an instance of ShouldRateLimit, I noticed that event NotificationSent is fired before NotificationSending, which cause a bug in the clockwork flow

also the event is already being fired inside parent::send so I removed it at all from this function


File path: 
src/RateLimitChannelManager.php

My change: 
```
public function send($notifiables, $notification)
    {
        if ($this->checkRateLimit($notifiables, $notification)) {
            parent::send($notifiables, $notification);
        }
    }
```
