### PR TITLE
Fix when using notifications facade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.1|^8.0",
-        "illuminate/support": "^7.0|^8.0"
+        "illuminate/support": "^7.0|^8.0|^9.0"
     },
     "require-dev": {
         "orchestra/testbench": "^6.17",

--- a/src/RateLimitedNotification.php
+++ b/src/RateLimitedNotification.php
@@ -55,6 +55,7 @@ trait RateLimitedNotification
 
     /**
      * The rate limiter instance.
+     *
      * @return RateLimiter|\Illuminate\Contracts\Foundation\Application|mixed
      */
     public function limiter()
@@ -64,6 +65,7 @@ trait RateLimitedNotification
 
     /**
      * Max attempts to accept in the throttled timeframe.
+     *
      * @return \Illuminate\Config\Repository|mixed
      */
     public function maxAttempts()
@@ -73,6 +75,7 @@ trait RateLimitedNotification
 
     /**
      * Time in seconds to throttle the notifications.
+     *
      * @return \Illuminate\Config\Repository|mixed
      */
     public function rateLimitForSeconds()
@@ -82,6 +85,7 @@ trait RateLimitedNotification
 
     /**
      * If to enable logging when a notification is skipped.
+     *
      * @return \Illuminate\Config\Repository|mixed
      */
     public function logSkippedNotifications()

--- a/src/RateLimitedNotification.php
+++ b/src/RateLimitedNotification.php
@@ -109,5 +109,4 @@ trait RateLimitedNotification
 
         return $notifiables;
     }
-
 }

--- a/src/RateLimitedNotification.php
+++ b/src/RateLimitedNotification.php
@@ -21,19 +21,16 @@ trait RateLimitedNotification
      */
     public function rateLimitKey($notification, $notifiables)
     {
-//        echo '<pre>';
-//        var_dump($notification);
-//        exit;
 
-//        $notifiables = $this->formatNotifiables($notifiables);
-//
-//        $notifiablesIds = (is_array($notifiables)) ? md5(implode(',', array_values($notifiables))) : $notifiables->implode('id', ',');
+        // Convert notifiables to Collection or Array
+        $notifiables = $this->formatNotifiables($notifiables);
+        $notifiablesIds = (is_array($notifiables)) ? md5(json_encode($notifiables)) : $notifiables->implode('id', ',');
 
         $parts = array_merge(
             [
                 config('laravel-notification-rate-limit.key_prefix'),
                 class_basename($notification),
-                $notifiables->id,
+                $notifiablesIds,
             ],
             $this->rateLimitCustomCacheKeyParts(),
             $this->rateLimitUniqueueNotifications($notification)

--- a/src/RateLimitedNotification.php
+++ b/src/RateLimitedNotification.php
@@ -3,7 +3,10 @@
 namespace Jamesmills\LaravelNotificationRateLimit;
 
 use Illuminate\Cache\RateLimiter;
+use Illuminate\Database\Eloquent\Collection as ModelCollection;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Notifications\Notification;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 
 /**
@@ -21,6 +24,10 @@ trait RateLimitedNotification
 //        echo '<pre>';
 //        var_dump($notification);
 //        exit;
+
+//        $notifiables = $this->formatNotifiables($notifiables);
+//
+//        $notifiablesIds = (is_array($notifiables)) ? md5(implode(',', array_values($notifiables))) : $notifiables->implode('id', ',');
 
         $parts = array_merge(
             [
@@ -89,4 +96,21 @@ trait RateLimitedNotification
     {
         return $this->shouldRateLimitUniqueNotifications ?? config('laravel-notification-rate-limit.should_rate_limit_unique_notifications');
     }
+
+    /**
+     * Format the notifiables into a Collection / array if necessary.
+     *
+     * @param  mixed  $notifiables
+     * @return \Illuminate\Database\Eloquent\Collection|array
+     */
+    protected function formatNotifiables($notifiables)
+    {
+        if (! $notifiables instanceof Collection && ! is_array($notifiables)) {
+            return $notifiables instanceof Model
+                ? new ModelCollection([$notifiables]) : [$notifiables];
+        }
+
+        return $notifiables;
+    }
+
 }

--- a/tests/RateLimitTest.php
+++ b/tests/RateLimitTest.php
@@ -2,7 +2,6 @@
 
 namespace Jamesmills\LaravelNotificationRateLimit\Tests;
 
-use Illuminate\Database\Eloquent\Collection as ModelCollection;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Notifications\ChannelManager;
 use Illuminate\Notifications\Events\NotificationSent;
@@ -78,7 +77,6 @@ class RateLimitTest extends TestCase
         Event::assertDispatched(NotificationSent::class);
         Event::assertNotDispatched(NotificationRateLimitReached::class);
         sleep(0.1);
-
     }
 
     /** @test */


### PR DESCRIPTION
When using a Model collection the rate limiter would fail with an error stating that the property "id" could not be found on the item only when called using the notifications facade: Notification::send($users, new TestNotification());

This change ensures that the $notifiables variable in the RateLimitedNotifications trait is either a Collection or an Array.
It then builds the "id" key appropriately.

Added a test to validate this process as well.