### PR TITLE
Fix #17 - Allow anonymous notifications to be rate-limited

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to `laravel-notification-rate-limit` will be documented in t
 
 - Add support for Laravel 9.x/10.x
 - Remove support for PHP 7.x/Laravel 7.x/8.x
+- Fixed [Issue #17](https://github.com/jamesmills/laravel-notification-rate-limit/issues/17): Anonymous notifications can now be rate-limited
+- New: You can now define a `rateLimitNotifiableKey()` method on a `Notifiable` object to override the value that will be used to identify that object as unique (by default, the primary key or `id` field)
 
 ## 1.1.0 - 2021-05-20
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,28 @@ public function rateLimitCustomCacheKeyParts()
     ];
 }
 ```
+
+### Customizing the Notifiable identifier
+
+By default, we use the primary key or `$id` field on the Notifiable instance to identify the recipient of a notification. 
+If for some reason you do not want to use `$id`, you can add a `rateLimitNotifiableKey()` method to your `Notifiable` model 
+and return a string containing the key to use.  For example, if multiple users
+could belong to a group and you only want one person (any person) in the group to
+receive the notification, you might return the group ID instead of the user ID:
+
+```php
+class User extends Authenticatable
+{
+    use Notifiable;
+
+    protected $fillable = ['id', 'name', 'email', 'groupId'];
     
+    public function rateLimitNotifiableKey(): string
+    {
+        return $this->group_id;
+    }
+}
+```
 
 ### Testing
 

--- a/tests/RateLimitTest.php
+++ b/tests/RateLimitTest.php
@@ -76,7 +76,6 @@ class RateLimitTest extends TestCase
         );
     }
 
-
     /** @test */
     public function it_will_skip_notifications_until_limit_expires()
     {
@@ -118,7 +117,9 @@ class RateLimitTest extends TestCase
         });
         // Ensure we are starting clean
         Log::swap(new LogFake);
-        Log::assertNotLogged(function (LogEntry $log) { return $log->level == 'notice'; });
+        Log::assertNotLogged(function (LogEntry $log) {
+            return $log->level == 'notice';
+        });
 
         // Send first notification and expect it to succeed
         Notification::route('mail', $this->anonymousEmailAddress)
@@ -127,7 +128,9 @@ class RateLimitTest extends TestCase
         Event::assertNotDispatched(NotificationRateLimitReached::class);
 
         // Send second notification and expect it to be skipped
-        Log::assertNotLogged(function (LogEntry $log) { return $log->level == 'notice'; });
+        Log::assertNotLogged(function (LogEntry $log) {
+            return $log->level == 'notice';
+        });
         Notification::route('mail', $this->anonymousEmailAddress)
             ->notify(new TestNotification());
 
@@ -279,7 +282,8 @@ class RateLimitTest extends TestCase
 
         Log::assertLogged(
             function (LogEntry $log) {
-                $expected_key = Str::lower(config('laravel-notification-rate-limit.key_prefix') . '.TestNotification.customKey');
+                $expected_key = Str::lower(config('laravel-notification-rate-limit.key_prefix').'.TestNotification.customKey');
+
                 return $log->context['key'] === $expected_key;
             }
         );

--- a/tests/RateLimitTest.php
+++ b/tests/RateLimitTest.php
@@ -3,12 +3,14 @@
 namespace Jamesmills\LaravelNotificationRateLimit\Tests;
 
 use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Notifications\AnonymousNotifiable;
 use Illuminate\Notifications\ChannelManager;
 use Illuminate\Notifications\Events\NotificationSent;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Str;
 use Jamesmills\LaravelNotificationRateLimit\Events\NotificationRateLimitReached;
 use Jamesmills\LaravelNotificationRateLimit\RateLimitChannelManager;
 use TiMacDonald\Log\LogEntry;
@@ -20,6 +22,9 @@ class RateLimitTest extends TestCase
 
     private $user;
     private $otherUser;
+    private $customRateLimitKeyUser;
+    private $anonymousEmailAddress;
+    private $otherAnonymousEmailAddress;
 
     public function setUp(): void
     {
@@ -30,6 +35,14 @@ class RateLimitTest extends TestCase
 
         $this->user = new User(['id' => $this->faker->numberBetween(1, 10000), 'name' => $this->faker->name, 'email' => $this->faker->email]);
         $this->otherUser = new User(['id' => $this->faker->numberBetween(1, 10000), 'name' => $this->faker->name, 'email' => $this->faker->email]);
+        $this->customRateLimitKeyUser = new UserWithCustomRateLimitKey([
+            'id' => $this->faker->numberBetween(10001, 20000),
+            'name' => $this->faker->name,
+            'email' => $this->faker->email,
+        ]);
+
+        $this->anonymousEmailAddress = $this->faker->freeEmail();
+        $this->otherAnonymousEmailAddress = $this->faker->companyEmail();
     }
 
     /** @test */
@@ -44,6 +57,25 @@ class RateLimitTest extends TestCase
         Notification::assertSentTo([$this->user], TestNotification::class);
         sleep(0.1);
     }
+
+    public function it_can_send_an_anonymous_notification()
+    {
+        Notification::fake();
+
+        Notification::assertNothingSent();
+
+        Notification::route('mail', $this->anonymousEmailAddress)
+            ->notify(new TestNotification());
+
+        Notification::assertSentTo(
+            new AnonymousNotifiable(),
+            TestNotification::class,
+            function ($notification, $channels, $notifiable) {
+                return $notifiable->routes['mail'] == $this->anonymousEmailAddress;
+            }
+        );
+    }
+
 
     /** @test */
     public function it_will_skip_notifications_until_limit_expires()
@@ -69,6 +101,36 @@ class RateLimitTest extends TestCase
             fn (LogEntry $log) => $log->level === 'notice'
         );
         $this->user->notify(new TestNotification());
+        Event::assertDispatched(NotificationRateLimitReached::class);
+        Log::assertLogged(
+            fn (LogEntry $log) => $log->level === 'notice'
+        );
+    }
+
+    /** @test */
+    public function it_will_skip_notifications_to_anonymous_users_until_limit_expires()
+    {
+        Event::fake();
+        Notification::fake();
+
+        $this->app->singleton(ChannelManager::class, function ($app) {
+            return new RateLimitChannelManager($app);
+        });
+        // Ensure we are starting clean
+        Log::swap(new LogFake);
+        Log::assertNotLogged(function (LogEntry $log) { return $log->level == 'notice'; });
+
+        // Send first notification and expect it to succeed
+        Notification::route('mail', $this->anonymousEmailAddress)
+            ->notify(new TestNotification());
+        Event::assertDispatched(NotificationSent::class);
+        Event::assertNotDispatched(NotificationRateLimitReached::class);
+
+        // Send second notification and expect it to be skipped
+        Log::assertNotLogged(function (LogEntry $log) { return $log->level == 'notice'; });
+        Notification::route('mail', $this->anonymousEmailAddress)
+            ->notify(new TestNotification());
+
         Event::assertDispatched(NotificationRateLimitReached::class);
         Log::assertLogged(
             fn (LogEntry $log) => $log->level === 'notice'
@@ -111,6 +173,50 @@ class RateLimitTest extends TestCase
     }
 
     /** @test */
+    public function it_does_not_get_confused_between_multiple_anonymous_users()
+    {
+        Event::fake();
+        Notification::fake();
+
+        $this->app->singleton(ChannelManager::class, function ($app) {
+            return new RateLimitChannelManager($app);
+        });
+        Config::set('laravel-notification-rate-limit.rate_limit_seconds', 10);
+
+        // Ensure we are starting clean
+        Log::swap(new LogFake);
+        Log::assertNotLogged(
+            fn (LogEntry $log) => $log->level === 'notice'
+        );
+
+        // Send first notification and expect it to succeed
+        Notification::route('mail', $this->anonymousEmailAddress)
+            ->notify(new TestNotification());
+
+        Event::assertDispatched(NotificationSent::class);
+        Event::assertNotDispatched(NotificationRateLimitReached::class);
+
+        // Send a notification to another user and expect it to succeed
+        Notification::route('mail', $this->otherAnonymousEmailAddress)
+            ->notify(new TestNotification());
+
+        Event::assertDispatched(NotificationSent::class);
+        Event::assertNotDispatched(NotificationRateLimitReached::class);
+        Log::assertNotLogged(
+            fn (LogEntry $log) => $log->level === 'notice'
+        );
+
+        // Send a second notice to the first user and expect it to be skipped
+        Notification::route('mail', $this->anonymousEmailAddress)
+            ->notify(new TestNotification());
+
+        Event::assertDispatched(NotificationRateLimitReached::class);
+        Log::assertLogged(
+            fn (LogEntry $log) => $log->level === 'notice'
+        );
+    }
+
+    /** @test */
     public function it_will_resume_notifications_after_expiration()
     {
         Event::fake();
@@ -140,6 +246,42 @@ class RateLimitTest extends TestCase
         Event::assertNotDispatched(NotificationRateLimitReached::class);
         Log::assertNotLogged(
             fn (LogEntry $log) => $log->level === 'notice'
+        );
+    }
+
+    /** @test */
+    public function it_will_utilize_custom_rate_limit_keys()
+    {
+        Event::fake();
+        Notification::fake();
+
+        $this->app->singleton(ChannelManager::class, function ($app) {
+            return new RateLimitChannelManager($app);
+        });
+        // Ensure we are starting clean.
+        Log::swap(new LogFake);
+        Log::assertNotLogged(
+            fn (LogEntry $log) => $log->level === 'notice'
+        );
+
+        // Send notification and expect it to succeed.
+        $this->customRateLimitKeyUser->notify(new TestNotification());
+        Event::assertDispatched(NotificationSent::class);
+        Event::assertNotDispatched(NotificationRateLimitReached::class);
+        Log::assertNotLogged(
+            fn (LogEntry $log) => $log->level === 'notice'
+        );
+
+        // Send a second notification and expect it to fail. Verify that
+        // the cache key in use included the 'customKey' value.
+        $this->customRateLimitKeyUser->notify(new TestNotification());
+        Event::assertDispatched(NotificationRateLimitReached::class);
+
+        Log::assertLogged(
+            function (LogEntry $log) {
+                $expected_key = Str::lower(config('laravel-notification-rate-limit.key_prefix') . '.TestNotification.customKey');
+                return $log->context['key'] === $expected_key;
+            }
         );
     }
 }

--- a/tests/UserWithCustomRateLimitKey.php
+++ b/tests/UserWithCustomRateLimitKey.php
@@ -4,6 +4,7 @@ namespace Jamesmills\LaravelNotificationRateLimit\Tests;
 
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+
 class UserWithCustomRateLimitKey extends Authenticatable
 {
     use Notifiable;

--- a/tests/UserWithCustomRateLimitKey.php
+++ b/tests/UserWithCustomRateLimitKey.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Jamesmills\LaravelNotificationRateLimit\Tests;
+
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Notifications\Notifiable;
+class UserWithCustomRateLimitKey extends Authenticatable
+{
+    use Notifiable;
+    protected $table = 'users';
+    protected $fillable = ['id', 'name', 'email'];
+
+    public function rateLimitNotifiableKey(): string
+    {
+        return 'customKey';
+    }
+}


### PR DESCRIPTION
As reported in #17 , anonymous notifications failed when passing through the rate limiter because they lack an 'id' property.  We now generate the 'id' more intelligently, and if no 'id' can be determined than an md5 of the notifiables array is used in its place. 

In the process, added some flexibility to allow individual Notifiable models to define what 'id' value the rate limiter will receive.