### PR TITLE
Support per-Notifiable rate limiting when sending to multiple recipients via the Notifications facade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to `laravel-notification-rate-limit` will be documented in t
 - Add support for Laravel 9.x/10.x
 - Remove support for PHP 7.x/Laravel 7.x/8.x
 - Fixed [Issue #17](https://github.com/jamesmills/laravel-notification-rate-limit/issues/17): Anonymous notifications can now be rate-limited
+- Fixed: The rate limiter now works with multi-recipient notifications sent via the `Notification::send()` facade
 - New: You can now define a `rateLimitNotifiableKey()` method on a `Notifiable` object to override the value that will be used to identify that object as unique (by default, the primary key or `id` field)
 
 ## 1.1.0 - 2021-05-20

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.1|^8.0",
-        "illuminate/support": "^7.0|^8.0"
+        "illuminate/support": "^7.0|^8.0|^9.0"
     },
     "require-dev": {
         "orchestra/testbench": "^6.17",

--- a/src/RateLimitChannelManager.php
+++ b/src/RateLimitChannelManager.php
@@ -2,9 +2,9 @@
 
 namespace Jamesmills\LaravelNotificationRateLimit;
 
-use Illuminate\Notifications\ChannelManager;
 use Illuminate\Database\Eloquent\Collection as ModelCollection;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Notifications\ChannelManager;
 use Illuminate\Support\Collection;
 
 class RateLimitChannelManager extends ChannelManager
@@ -16,7 +16,7 @@ class RateLimitChannelManager extends ChannelManager
         } else {
             $notifiables = $this->formatNotifiables($notifiables);
 
-            foreach($notifiables as $notifiable) {
+            foreach ($notifiables as $notifiable) {
                 if ($this->checkRateLimit($notifiable, $notification)) {
                     parent::send($notifiable, $notification);
                 }
@@ -44,6 +44,7 @@ class RateLimitChannelManager extends ChannelManager
         }
 
         $notification->limiter()->hit($key, $notification->rateLimitForSeconds());
+
         return true;
     }
 

--- a/src/RateLimitedNotification.php
+++ b/src/RateLimitedNotification.php
@@ -55,6 +55,7 @@ trait RateLimitedNotification
 
     /**
      * The rate limiter instance.
+     *
      * @return RateLimiter|\Illuminate\Contracts\Foundation\Application|mixed
      */
     public function limiter()
@@ -64,6 +65,7 @@ trait RateLimitedNotification
 
     /**
      * Max attempts to accept in the throttled timeframe.
+     *
      * @return \Illuminate\Config\Repository|mixed
      */
     public function maxAttempts()
@@ -73,6 +75,7 @@ trait RateLimitedNotification
 
     /**
      * Time in seconds to throttle the notifications.
+     *
      * @return \Illuminate\Config\Repository|mixed
      */
     public function rateLimitForSeconds()
@@ -82,6 +85,7 @@ trait RateLimitedNotification
 
     /**
      * If to enable logging when a notification is skipped.
+     *
      * @return \Illuminate\Config\Repository|mixed
      */
     public function logSkippedNotifications()

--- a/src/RateLimitedNotification.php
+++ b/src/RateLimitedNotification.php
@@ -109,5 +109,4 @@ trait RateLimitedNotification
 
         return $notifiables;
     }
-
 }

--- a/src/RateLimitedNotification.php
+++ b/src/RateLimitedNotification.php
@@ -21,19 +21,16 @@ trait RateLimitedNotification
      */
     public function rateLimitKey($notification, $notifiables)
     {
-//        echo '<pre>';
-//        var_dump($notification);
-//        exit;
 
-//        $notifiables = $this->formatNotifiables($notifiables);
-//
-//        $notifiablesIds = (is_array($notifiables)) ? md5(implode(',', array_values($notifiables))) : $notifiables->implode('id', ',');
+        // Convert notifiables to Collection or Array
+        $notifiables = $this->formatNotifiables($notifiables);
+        $notifiablesIds = (is_array($notifiables)) ? md5(json_encode($notifiables)) : $notifiables->implode('id', ',');
 
         $parts = array_merge(
             [
                 config('laravel-notification-rate-limit.key_prefix'),
                 class_basename($notification),
-                $notifiables->id,
+                $notifiablesIds,
             ],
             $this->rateLimitCustomCacheKeyParts(),
             $this->rateLimitUniqueueNotifications($notification)

--- a/src/RateLimitedNotification.php
+++ b/src/RateLimitedNotification.php
@@ -3,7 +3,10 @@
 namespace Jamesmills\LaravelNotificationRateLimit;
 
 use Illuminate\Cache\RateLimiter;
+use Illuminate\Database\Eloquent\Collection as ModelCollection;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Notifications\Notification;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 
 /**
@@ -21,6 +24,10 @@ trait RateLimitedNotification
 //        echo '<pre>';
 //        var_dump($notification);
 //        exit;
+
+//        $notifiables = $this->formatNotifiables($notifiables);
+//
+//        $notifiablesIds = (is_array($notifiables)) ? md5(implode(',', array_values($notifiables))) : $notifiables->implode('id', ',');
 
         $parts = array_merge(
             [
@@ -89,4 +96,21 @@ trait RateLimitedNotification
     {
         return $this->shouldRateLimitUniqueNotifications ?? config('laravel-notification-rate-limit.should_rate_limit_unique_notifications');
     }
+
+    /**
+     * Format the notifiables into a Collection / array if necessary.
+     *
+     * @param  mixed  $notifiables
+     * @return \Illuminate\Database\Eloquent\Collection|array
+     */
+    protected function formatNotifiables($notifiables)
+    {
+        if (! $notifiables instanceof Collection && ! is_array($notifiables)) {
+            return $notifiables instanceof Model
+                ? new ModelCollection([$notifiables]) : [$notifiables];
+        }
+
+        return $notifiables;
+    }
+
 }

--- a/src/RateLimitedNotification.php
+++ b/src/RateLimitedNotification.php
@@ -92,15 +92,15 @@ trait RateLimitedNotification
             $key = $notifiable->rateLimitNotifiableKey();
         }
 
-        if (!$key && method_exists($notifiable, 'getKey')) {
+        if (! $key && method_exists($notifiable, 'getKey')) {
             $key = $notifiable->getKey();
         }
 
-        if (!$key && property_exists($notifiable, 'id')) {
+        if (! $key && property_exists($notifiable, 'id')) {
             $key = $notifiable->id;
         }
 
-        if (!$key) {
+        if (! $key) {
             $key = md5(json_encode($notifiable));
         }
 

--- a/tests/RateLimitTest.php
+++ b/tests/RateLimitTest.php
@@ -2,7 +2,6 @@
 
 namespace Jamesmills\LaravelNotificationRateLimit\Tests;
 
-use Illuminate\Database\Eloquent\Collection as ModelCollection;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Notifications\ChannelManager;
 use Illuminate\Notifications\Events\NotificationSent;
@@ -78,7 +77,6 @@ class RateLimitTest extends TestCase
         Event::assertDispatched(NotificationSent::class);
         Event::assertNotDispatched(NotificationRateLimitReached::class);
         sleep(0.1);
-
     }
 
     /** @test */

--- a/tests/RateLimitTest.php
+++ b/tests/RateLimitTest.php
@@ -3,7 +3,6 @@
 namespace Jamesmills\LaravelNotificationRateLimit\Tests;
 
 use Illuminate\Foundation\Testing\WithFaker;
-use Illuminate\Notifications\AnonymousNotifiable;
 use Illuminate\Notifications\ChannelManager;
 use Illuminate\Notifications\Events\NotificationSent;
 use Illuminate\Support\Facades\Config;
@@ -94,13 +93,14 @@ class RateLimitTest extends TestCase
             NotificationSent::class,
             function (NotificationSent $ns) use (&$wasSent) {
                 $wasSent[$ns->notifiable->id] = true;
+
                 return $ns->notifiable->is($this->user) ||
                     $ns->notifiable->is($this->otherUser);
             }
         );
         $this->assertSame($wasSent, [
             $this->user->id => true,
-            $this->otherUser->id => true
+            $this->otherUser->id => true,
         ]);
     }
 

--- a/tests/RateLimitTest.php
+++ b/tests/RateLimitTest.php
@@ -20,11 +20,12 @@ class RateLimitTest extends TestCase
 {
     use WithFaker;
 
-    private $user;
-    private $otherUser;
-    private $customRateLimitKeyUser;
-    private $anonymousEmailAddress;
-    private $otherAnonymousEmailAddress;
+    private User $user;
+    private User $otherUser;
+    private UserWithCustomRateLimitKey $customRateLimitKeyUser;
+    private string $anonymousEmailAddress;
+    private string $otherAnonymousEmailAddress;
+    private RateLimitChannelManager $rateLimitChannelManager;
 
     public function setUp(): void
     {
@@ -43,70 +44,64 @@ class RateLimitTest extends TestCase
 
         $this->anonymousEmailAddress = $this->faker->freeEmail();
         $this->otherAnonymousEmailAddress = $this->faker->companyEmail();
+
+        Notification::fake();
+        Event::fake();
+        Log::swap(new LogFake);
+
+        // When Notification is faked, Notification::send() and Notification::route
+        // do not call our channel manager, so we cannot use the Notification tests to
+        // verify that m
+        // that works, Notification::send()/route() will work in a live application.
+        $this->app->singleton(ChannelManager::class, function ($app) {
+            return new RateLimitChannelManager($app);
+        });
+
+        $this->rateLimitChannelManager = app(ChannelManager::class);
     }
 
     /** @test */
     public function it_can_send_a_notification()
     {
-        Notification::fake();
-
-        Notification::assertNothingSent();
-
-        Notification::send([$this->user], new TestNotification());
-
-        Notification::assertSentTo([$this->user], TestNotification::class);
+        $this->user->notify(new TestNotification());
+        Event::assertDispatched(NotificationSent::class, function (NotificationSent $evt) {
+            return $evt->notifiable->is($this->user);
+        });
     }
 
+    /** @test */
     public function it_can_send_an_anonymous_notification()
     {
-        Notification::fake();
-
-        Notification::assertNothingSent();
-
         Notification::route('mail', $this->anonymousEmailAddress)
             ->notify(new TestNotification());
 
-        Notification::assertSentTo(
-            new AnonymousNotifiable(),
-            TestNotification::class,
-            function ($notification, $channels, $notifiable) {
-                return $notifiable->routes['mail'] == $this->anonymousEmailAddress;
-            }
+        Event::assertDispatched(
+            NotificationSent::class,
+            fn ($ns) => $ns->notifiable->routes['mail'] == $this->anonymousEmailAddress
         );
+
+        Event::assertNotDispatched(NotificationRateLimitReached::class);
     }
 
     /** @test */
     public function it_can_send_notification_to_two_users(): void
     {
-        Notification::fake();
-
-        Notification::assertNothingSent();
-
-        Notification::send([$this->user, $this->otherUser], new TestNotification());
-
-        Notification::assertSentTo([$this->user, $this->otherUser], TestNotification::class);
-    }
-
-    /** @test */
-    public function it_can_send_notification_to_two_ratelimited_users(): void
-    {
-        Event::fake();
-        Notification::fake();
-
-        Log::swap(new LogFake);
-        Log::assertNotLogged(
-            fn (LogEntry $log) => $log->level === 'notice'
-        );
-
-        Notification::assertNothingSent();
-
-        // Have to call the RateLimitChannelManager directly as the facade is not testable
-        // e.g. Notification::send does not trigger the RateLimitChannelManager
-        $rateLimitChannelManager = new RateLimitChannelManager($this->app);
-        $rateLimitChannelManager->send([$this->user, $this->otherUser], new TestNotification());
-
+        $this->rateLimitChannelManager->send([$this->user, $this->otherUser], new TestNotification());
         Event::assertDispatchedTimes(NotificationSent::class, 2);
-        Event::assertNotDispatched(NotificationRateLimitReached::class);
+
+        $wasSent = [$this->user->id => false, $this->otherUser->id => false];
+        Event::assertDispatched(
+            NotificationSent::class,
+            function (NotificationSent $ns) use (&$wasSent) {
+                $wasSent[$ns->notifiable->id] = true;
+                return $ns->notifiable->is($this->user) ||
+                    $ns->notifiable->is($this->otherUser);
+            }
+        );
+        $this->assertSame($wasSent, [
+            $this->user->id => true,
+            $this->otherUser->id => true
+        ]);
     }
 
     /** @test */
@@ -114,27 +109,19 @@ class RateLimitTest extends TestCase
     {
         Config::set('laravel-notification-rate-limit.rate_limit_seconds', 1);
 
-        Event::fake();
-        Notification::fake();
-        Log::swap(new LogFake);
-
-        // Have to call the RateLimitChannelManager directly as the facade is not testable
-        // e.g. Notification::send does not trigger the RateLimitChannelManager
-        $rateLimitChannelManager = new RateLimitChannelManager($this->app);
-
         // Send a notification to one user, and expect it to succeed
-        $rateLimitChannelManager->send($this->user, new TestNotification());
+        $this->rateLimitChannelManager->send($this->user, new TestNotification());
         Event::assertDispatched(NotificationSent::class);
         Event::assertNotDispatched(NotificationRateLimitReached::class);
 
         // Send the same notification to two users, and expect it to only be sent to
         // the second user
-        $rateLimitChannelManager->send([$this->user, $this->otherUser], new TestNotification());
+        $this->rateLimitChannelManager->send([$this->user, $this->otherUser], new TestNotification());
         Event::assertDispatchedTimes(NotificationSent::class, 2);
         Event::assertDispatchedTimes(NotificationRateLimitReached::class, 1);
 
         // Send the same notification again and nobody should get it (expect 2 limit reached events)
-        $rateLimitChannelManager->send([$this->user, $this->otherUser], new TestNotification());
+        $this->rateLimitChannelManager->send([$this->user, $this->otherUser], new TestNotification());
         Event::assertDispatchedTimes(NotificationSent::class, 2);
         Event::assertDispatchedTimes(NotificationRateLimitReached::class, 3);
 
@@ -142,7 +129,7 @@ class RateLimitTest extends TestCase
         sleep(2);
 
         // Try to send again to both users; both should succeed
-        $rateLimitChannelManager->send([$this->user, $this->otherUser], new TestNotification());
+        $this->rateLimitChannelManager->send([$this->user, $this->otherUser], new TestNotification());
         Event::assertDispatchedTimes(NotificationSent::class, 4);
         Event::assertDispatchedTimes(NotificationRateLimitReached::class, 3);
     }
@@ -150,26 +137,15 @@ class RateLimitTest extends TestCase
     /** @test */
     public function it_will_skip_notifications_until_limit_expires()
     {
-        Event::fake();
-        Notification::fake();
-
-        $this->app->singleton(ChannelManager::class, function ($app) {
-            return new RateLimitChannelManager($app);
-        });
-        // Ensure we are starting clean
-        Log::swap(new LogFake);
-        Log::assertNotLogged(
-            fn (LogEntry $log) => $log->level === 'notice'
-        );
-
         // Send first notification and expect it to succeed
         $this->user->notify(new TestNotification());
         Event::assertDispatched(NotificationSent::class);
         Event::assertNotDispatched(NotificationRateLimitReached::class);
-        // Send second notification and expect it to be skipped
         Log::assertNotLogged(
             fn (LogEntry $log) => $log->level === 'notice'
         );
+
+        // Send second notification and expect it to be skipped
         $this->user->notify(new TestNotification());
         Event::assertDispatched(NotificationRateLimitReached::class);
         Log::assertLogged(
@@ -180,31 +156,18 @@ class RateLimitTest extends TestCase
     /** @test */
     public function it_will_skip_notifications_to_anonymous_users_until_limit_expires()
     {
-        Event::fake();
-        Notification::fake();
-
-        $this->app->singleton(ChannelManager::class, function ($app) {
-            return new RateLimitChannelManager($app);
-        });
-        // Ensure we are starting clean
-        Log::swap(new LogFake);
-        Log::assertNotLogged(function (LogEntry $log) {
-            return $log->level == 'notice';
-        });
-
         // Send first notification and expect it to succeed
         Notification::route('mail', $this->anonymousEmailAddress)
             ->notify(new TestNotification());
         Event::assertDispatched(NotificationSent::class);
         Event::assertNotDispatched(NotificationRateLimitReached::class);
-
-        // Send second notification and expect it to be skipped
         Log::assertNotLogged(function (LogEntry $log) {
             return $log->level == 'notice';
         });
+
+        // Send second notification and expect it to be skipped
         Notification::route('mail', $this->anonymousEmailAddress)
             ->notify(new TestNotification());
-
         Event::assertDispatched(NotificationRateLimitReached::class);
         Log::assertLogged(
             fn (LogEntry $log) => $log->level === 'notice'
@@ -214,31 +177,23 @@ class RateLimitTest extends TestCase
     /** @test */
     public function it_does_not_get_confused_between_multiple_users()
     {
-        Event::fake();
-        Notification::fake();
-
-        $this->app->singleton(ChannelManager::class, function ($app) {
-            return new RateLimitChannelManager($app);
-        });
-        Config::set('laravel-notification-rate-limit.rate_limit_seconds', 10);
-
-        // Ensure we are starting clean
-        Log::swap(new LogFake);
-        Log::assertNotLogged(
-            fn (LogEntry $log) => $log->level === 'notice'
-        );
         // Send first notification and expect it to succeed
         $this->user->notify(new TestNotification());
         Event::assertDispatched(NotificationSent::class);
         Event::assertNotDispatched(NotificationRateLimitReached::class);
+        Log::assertNotLogged(
+            fn (LogEntry $log) => $log->level === 'notice'
+        );
+
         // Send a notification to another user and expect it to succeed
         $this->otherUser->notify(new TestNotification());
         Event::assertDispatched(NotificationSent::class);
         Event::assertNotDispatched(NotificationRateLimitReached::class);
-        // Send a second notice to the first user and expect it to be skipped
         Log::assertNotLogged(
             fn (LogEntry $log) => $log->level === 'notice'
         );
+
+        // Send a second notice to the first user and expect it to be skipped
         $this->user->notify(new TestNotification());
         Event::assertDispatched(NotificationRateLimitReached::class);
         Log::assertLogged(
@@ -249,31 +204,18 @@ class RateLimitTest extends TestCase
     /** @test */
     public function it_does_not_get_confused_between_multiple_anonymous_users()
     {
-        Event::fake();
-        Notification::fake();
-
-        $this->app->singleton(ChannelManager::class, function ($app) {
-            return new RateLimitChannelManager($app);
-        });
-        Config::set('laravel-notification-rate-limit.rate_limit_seconds', 10);
-
-        // Ensure we are starting clean
-        Log::swap(new LogFake);
+        // Send first notification and expect it to succeed
+        Notification::route('mail', $this->anonymousEmailAddress)
+            ->notify(new TestNotification());
+        Event::assertDispatched(NotificationSent::class);
+        Event::assertNotDispatched(NotificationRateLimitReached::class);
         Log::assertNotLogged(
             fn (LogEntry $log) => $log->level === 'notice'
         );
 
-        // Send first notification and expect it to succeed
-        Notification::route('mail', $this->anonymousEmailAddress)
-            ->notify(new TestNotification());
-
-        Event::assertDispatched(NotificationSent::class);
-        Event::assertNotDispatched(NotificationRateLimitReached::class);
-
         // Send a notification to another user and expect it to succeed
         Notification::route('mail', $this->otherAnonymousEmailAddress)
             ->notify(new TestNotification());
-
         Event::assertDispatched(NotificationSent::class);
         Event::assertNotDispatched(NotificationRateLimitReached::class);
         Log::assertNotLogged(
@@ -283,7 +225,6 @@ class RateLimitTest extends TestCase
         // Send a second notice to the first user and expect it to be skipped
         Notification::route('mail', $this->anonymousEmailAddress)
             ->notify(new TestNotification());
-
         Event::assertDispatched(NotificationRateLimitReached::class);
         Log::assertLogged(
             fn (LogEntry $log) => $log->level === 'notice'
@@ -293,19 +234,8 @@ class RateLimitTest extends TestCase
     /** @test */
     public function it_will_resume_notifications_after_expiration()
     {
-        Event::fake();
-        Notification::fake();
-
         Config::set('laravel-notification-rate-limit.rate_limit_seconds', 1);
 
-        $this->app->singleton(ChannelManager::class, function ($app) {
-            return new RateLimitChannelManager($app);
-        });
-        // Ensure we are starting clean.
-        Log::swap(new LogFake);
-        Log::assertNotLogged(
-            fn (LogEntry $log) => $log->level === 'notice'
-        );
         // Send first notification and expect it to succeed.
         $this->user->notify(new TestNotification());
         Event::assertDispatched(NotificationSent::class);
@@ -313,8 +243,10 @@ class RateLimitTest extends TestCase
         Log::assertNotLogged(
             fn (LogEntry $log) => $log->level === 'notice'
         );
+
         // Wait until the rate limiter has expired
-        sleep(1);
+        sleep(2);
+
         // Send another notification and expect it to succeed.
         Event::assertDispatched(NotificationSent::class);
         Event::assertNotDispatched(NotificationRateLimitReached::class);
@@ -326,18 +258,6 @@ class RateLimitTest extends TestCase
     /** @test */
     public function it_will_utilize_custom_rate_limit_keys()
     {
-        Event::fake();
-        Notification::fake();
-
-        $this->app->singleton(ChannelManager::class, function ($app) {
-            return new RateLimitChannelManager($app);
-        });
-        // Ensure we are starting clean.
-        Log::swap(new LogFake);
-        Log::assertNotLogged(
-            fn (LogEntry $log) => $log->level === 'notice'
-        );
-
         // Send notification and expect it to succeed.
         $this->customRateLimitKeyUser->notify(new TestNotification());
         Event::assertDispatched(NotificationSent::class);
@@ -350,7 +270,6 @@ class RateLimitTest extends TestCase
         // the cache key in use included the 'customKey' value.
         $this->customRateLimitKeyUser->notify(new TestNotification());
         Event::assertDispatched(NotificationRateLimitReached::class);
-
         Log::assertLogged(
             function (LogEntry $log) {
                 $expected_key = Str::lower(config('laravel-notification-rate-limit.key_prefix').'.TestNotification.customKey');


### PR DESCRIPTION
Adaption from the suggestion solution in PR #18 to properly handle notifications that are sent to multiple recipients via the `Notification::send()` facade.  Each recipient gets their own limiter/cache key, such that if a given notification is sent to multiple recipients, each recipient is tracked individually.

