### PR TITLE
Add additional information fields to rate limited notification event

### DIFF
--- a/src/Events/NotificationRateLimitReached.php
+++ b/src/Events/NotificationRateLimitReached.php
@@ -18,5 +18,6 @@ class NotificationRateLimitReached
 
     public function __construct(
         public Notification $notification,
-    ) {}
+    ) {
+    }
 }

--- a/src/Events/NotificationRateLimitReached.php
+++ b/src/Events/NotificationRateLimitReached.php
@@ -11,10 +11,12 @@ class NotificationRateLimitReached
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
-    public $notification;
+    // TODO: Move to required constructor properties in a future major version upgrade
+    public mixed $notifiable = null;
+    public ?string $key = null;
+    public ?int $availableIn = null;
 
-    public function __construct(Notification $notification)
-    {
-        $this->notification = $notification;
-    }
+    public function __construct(
+        public Notification $notification,
+    ) {}
 }


### PR DESCRIPTION
Adds the cache key, time to allowed sending, and 'notifiable' instance to the event that is dispatched when a rate limit is hit to enable more sophisticated processing at the application level.

NotificationRateLimitReached event constructor signature not changed yet, as this would be a breaking change for any existing custom events. Instead these properties are filled in if they are found to exist on the event once constructed.