### PR TITLE
Added md5 to handle too many notification parameters

### DIFF
--- a/src/RateLimitedNotification.php
+++ b/src/RateLimitedNotification.php
@@ -33,7 +33,7 @@ trait RateLimitedNotification
     public function rateLimitUniqueueNotifications($notification)
     {
         if ($this->shouldRateLimitUniqueNotifications() == true) {
-            return [serialize($notification)];
+            return [md5(serialize($notification))];
         }
 
         return [];


### PR DESCRIPTION
When the shouldRateLimitUniqueNotifications option is enabled,  the code will return MD5 hash of the serialized notification. This approach ensures that the cache key remains within a reasonable size.

Close #39 