### PR TITLE
Guard against RateLimiter failures causing notifications to fail

### DIFF
--- a/src/RateLimitChannelManager.php
+++ b/src/RateLimitChannelManager.php
@@ -15,7 +15,7 @@ class RateLimitChannelManager extends ChannelManager
     {
         // If this notification is going to be queued, we do not check for rate limiting
         // until the notification is actually picked up for sending in the queue via sendNow().
-        if ($notification instanceof ShouldRateLimit && !$notification instanceof ShouldQueue) {
+        if ($notification instanceof ShouldRateLimit && ! $notification instanceof ShouldQueue) {
             $this->sendWithRateLimitCheck($notifiables, $notification, 'send');
         } else {
             parent::send($notifiables, $notification);
@@ -86,14 +86,14 @@ class RateLimitChannelManager extends ChannelManager
             } catch (\Exception $e) {
                 $notification_type = get_class($notifiable);
 
-                logger()->warning('Notification rate limiter encountered an internal exception (notification type: ' . $notification_type . '); bypassing limiter. Error: ' . $e->getMessage());
+                logger()->warning('Notification rate limiter encountered an internal exception (notification type: '.$notification_type.'); bypassing limiter. Error: '.$e->getMessage());
                 report($e);
             }
 
-            if (!$sending_permitted) {
+            if (! $sending_permitted) {
                 continue;
             }
-            
+
             parent::$sending_function($notifiable, $notification);
         }
     }
@@ -105,7 +105,7 @@ class RateLimitChannelManager extends ChannelManager
      */
     protected function formatNotifiables(mixed $notifiables): ModelCollection|Collection|array
     {
-        if (!$notifiables instanceof Collection && !is_array($notifiables)) {
+        if (! $notifiables instanceof Collection && ! is_array($notifiables)) {
             return $notifiables instanceof Model
                 ? new ModelCollection([$notifiables]) : [$notifiables];
         }

--- a/src/RateLimitChannelManager.php
+++ b/src/RateLimitChannelManager.php
@@ -15,7 +15,7 @@ class RateLimitChannelManager extends ChannelManager
     {
         // If this notification is going to be queued, we do not check for rate limiting
         // until the notification is actually picked up for sending in the queue via sendNow().
-        if ($notification instanceof ShouldRateLimit && ! $notification instanceof ShouldQueue) {
+        if ($notification instanceof ShouldRateLimit && !$notification instanceof ShouldQueue) {
             $this->sendWithRateLimitCheck($notifiables, $notification, 'send');
         } else {
             parent::send($notifiables, $notification);
@@ -74,10 +74,27 @@ class RateLimitChannelManager extends ChannelManager
     {
         $notifiables = $this->formatNotifiables($notifiables);
 
+        // Send each notification, but protect against the possibility that the
+        // rate limiter itself might fail (e.g. due to the cache service not being
+        // available, or refusing to accept a cache key).  If our own
+        // rate limiting logic fails for some reason, we send the notification anyway.
         foreach ($notifiables as $notifiable) {
-            if ($this->checkRateLimit($notifiable, $notification)) {
-                parent::$sending_function($notifiable, $notification);
+            $sending_permitted = true;
+
+            try {
+                $sending_permitted = $this->checkRateLimit($notifiable, $notification);
+            } catch (\Exception $e) {
+                $notification_type = get_class($notifiable);
+
+                logger()->warning('Notification rate limiter encountered an internal exception (notification type: ' . $notification_type . '); bypassing limiter. Error: ' . $e->getMessage());
+                report($e);
             }
+
+            if (!$sending_permitted) {
+                continue;
+            }
+            
+            parent::$sending_function($notifiable, $notification);
         }
     }
 
@@ -88,7 +105,7 @@ class RateLimitChannelManager extends ChannelManager
      */
     protected function formatNotifiables(mixed $notifiables): ModelCollection|Collection|array
     {
-        if (! $notifiables instanceof Collection && ! is_array($notifiables)) {
+        if (!$notifiables instanceof Collection && !is_array($notifiables)) {
             return $notifiables instanceof Model
                 ? new ModelCollection([$notifiables]) : [$notifiables];
         }

--- a/tests/RateLimitTest.php
+++ b/tests/RateLimitTest.php
@@ -342,7 +342,6 @@ class RateLimitTest extends TestCase
         );
     }
 
-
     /** @test */
     public function it_will_send_notifications_even_if_limiter_check_fails()
     {


### PR DESCRIPTION
Partial resolution to issue #39.  We now guard against the possibility of the rate limiter implementation throwing an exception, which could result in important notifications not being sent to users. If some exception occurs during the course of our checking the rate limiter status, we now report and log the error but continue to send the notification in any event.

This may result in more notifications being sent than intended, but that failure mode is preferable to notifications not being sent at all.