### PR TITLE
Allow alternative 'unique notification' ID generation methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,15 @@ Rate Limiting Notifications in Laravel using Laravel's native rate limiter to av
 
 ## Version Compatability
 
-| Laravel | PHP     | Laravel-Notification-Rate-Limit | Date        |
-|:--------|:--------|:--------------------------------|:------------|
-| 7.x/8.x | 7.1/8.0 | 1.1.0                           | 2021-05-20  |
-| 9.x     | 8.0     | 2.1.0                           | 2023-08-26  |
-| 10.x    | 8.0/8.1 | 2.1.0                           | 2023-08-26  |
-| 10.x    | 8.2/8.3 | 2.2.0                           | 2024-03-18  |
-| 10.x    | 8.2/8.3 | 3.0.0                           | 2024-05-25  |
-| 11.x    | 8.2/8.3 | 2.2.0                           | 2024-03-18  |
-| 11.x    | 8.2/8.3 | 3.0.0                           | 2024-05-25  |
+| Laravel | PHP     | Laravel-Notification-Rate-Limit | Date       |
+|:--------|:--------|:--------------------------------|:-----------|
+| 7.x/8.x | 7.1/8.0 | 1.1.0                           | 2021-05-20 |
+| 9.x     | 8.0     | 2.1.0                           | 2023-08-26 |
+| 10.x    | 8.0/8.1 | 2.1.0                           | 2023-08-26 |
+| 10.x    | 8.2/8.3 | 2.2.0                           | 2024-03-18 |
+| 10.x    | 8.2/8.3 | 3.0.0                           | 2024-05-25 |
+| 11.x    | 8.2/8.3 | 2.2.0                           | 2024-03-18 |
+| 11.x    | 8.2/8.3 | 3.1.0                           | 2024-09-25 |
 
 ## Installation
 
@@ -114,7 +114,13 @@ protected $logSkippedNotifications = false;
     
 ### Skipping unique notifications
 
-By default, the Rate Limiter uses a cache key made up of some opinionated defaults. One of these default keys is `serialize($notification)`. You may wish to turn this off. 
+When determining whether a notification is subject to rate limiting, the package must make a decision about whether the notification is in fact the same as a previously sent notification.
+
+By default, the Rate Limiter uses a cache key made up of some opinionated defaults. One of these default keys is `serialize($notification)`, such that all of the notification properties will be included in the cache key. While this may work fine for most users, some cache systems may have a hard limit on the length of cache keys, and large notifications containing a significant amount of data may exceed that (see GitHub issue #39 for example).
+
+#### Disabling 'unqiue notification' checks
+
+You may wish to turn this off altogether, and use your own logic to construct a custom cache key instead. 
 
 Update globally with the `should_rate_limit_unique_notifications` config setting.
 
@@ -124,7 +130,21 @@ Update for an individual basis by adding the below to the Notification:
 protected $shouldRateLimitUniqueNotifications = false;
 ```
 
-### Customising the cache key
+#### Changing the 'unique notification' cache key mechanism
+
+Rather than turning unique notification determinations altogether or constructing a completely custom cache key, you may also choose to use a 'hash' of the `seriralize()` notification rather than the raw `serialize()`'d string itself.
+
+You can choose to use `serialize`, or any of the hashing algorithms supported by your PHP installation. You can confirm the list of available hashing mechanisms by checking the output of `hash_algos()`, but this will generally include standard algorithms such as `md5`, `sha1`, `sha256`, and so forth.
+
+Update globally with the `unique_notification_strategy` config setting.
+
+Update for an individual basis by adding an alternative strategy with a line such as the below to the Notification:
+
+```php
+protected $rateLimitUniqueNotificationStrategy = 'md5';
+```
+
+### Further customising the cache key
 
 You may want to customise the parts used in the cache key. You can do this by adding code such as the below to your Notification:
 

--- a/config/config.php
+++ b/config/config.php
@@ -51,17 +51,40 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Rate Limit Uniqueue Notifications
+    | Rate Limit Unique Notifications
     |--------------------------------------------------------------------------
     |
-    | By default one of the cache keys is a seralised string of the
-    | notification. This means that every property of the notification
-    | is used as the cache key. You can disable this if you want
-    | to have full control of what key is used.
+    | Enable this if you wish to rate limit unique notifications. This will
+    | allow multiple notifications of the same notification class to be sent,
+    | but only if the contents of the notifications is determined to be
+    | different in some way. Various strategies are offered for how this
+    | "unique" cache key is generated (see below). If you want full control
+    | over the cache key that is used to determine uniqueness, turn this off.
     |
     */
 
     'should_rate_limit_unique_notifications' => true,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Unique Notification Identification Strategy
+    |--------------------------------------------------------------------------
+    |
+    | If `should_rate_limit_unique_notifications` is set to true above, you
+    | can choose from one of several strategies that will be used to determine
+    | whether a given notification is or is not 'unique'.
+    |
+    | By default one of the cache keys is a seralised string of the
+    | notification. This means that every property of the notification
+    | is used as the cache key. Some cache systems may have a hard limit
+    | on the length of keys, so using a hashed key may be preferable.
+    |
+    | The strategy can either be 'serialize' (which uses the serialized
+    | text of the entire notification as a string), or one of the hashing
+    | algorithms available as reported by PHP's hash_algos(), e.g. md5, sha1.
+    */
+
+    'unique_notification_strategy' => 'serialize',
 
     /*
     |--------------------------------------------------------------------------

--- a/src/RateLimitedNotification.php
+++ b/src/RateLimitedNotification.php
@@ -42,7 +42,7 @@ trait RateLimitedNotification
             if ($strategy == 'serialize') {
                 return [$serialized_notification];
             } else {
-                if(! in_array($strategy, hash_algos())) {
+                if (! in_array($strategy, hash_algos())) {
                     throw new \Exception("Unsupported unique notification strategy hashing algorithm: $strategy");
                 }
 
@@ -97,7 +97,6 @@ trait RateLimitedNotification
     {
         return $this->shouldRateLimitUniqueNotifications ?? config('laravel-notification-rate-limit.should_rate_limit_unique_notifications');
     }
-
 
     /**
      * Returns the name of the hashing function to use for determining

--- a/tests/RateLimitTest.php
+++ b/tests/RateLimitTest.php
@@ -426,5 +426,4 @@ class RateLimitTest extends TestCase
             return $evt->notifiable->is($this->user);
         });
     }
-
 }

--- a/tests/RateLimitTest.php
+++ b/tests/RateLimitTest.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Str;
 use Jamesmills\LaravelNotificationRateLimit\Events\NotificationRateLimitReached;
 use Jamesmills\LaravelNotificationRateLimit\RateLimitChannelManager;
+use PHPUnit\Util\Test;
 use TiMacDonald\Log\LogEntry;
 use TiMacDonald\Log\LogFake;
 
@@ -365,4 +366,65 @@ class RateLimitTest extends TestCase
             return $evt->notifiable->is($this->user);
         });
     }
+
+    /** @test */
+    public function it_will_generate_keys_using_global_chosen_unique_strategy()
+    {
+        Config::set('laravel-notification-rate-limit.should_rate_limit_unique_notifications', true);
+        Config::set('laravel-notification-rate-limit.unique_notification_strategy', 'serialize');
+
+        $notification = new TestNotification();
+        $key = $notification->rateLimitKey($notification, $this->user);
+
+        $this->assertMatchesRegularExpression(
+            '/^laravelnotificationratelimit\.testnotification.(\d+)\.o:62:"jamesmills\\\\laravelnotificationratelimit\\\\tests\\\\testnotification":0:\{\}$/',
+            $key
+        );
+
+        Config::set('laravel-notification-rate-limit.unique_notification_strategy', 'md5');
+        $key = $notification->rateLimitKey($notification, $this->user);
+        $this->assertMatchesRegularExpression(
+            '/^laravelnotificationratelimit\.testnotification.(\d+)\.e31474a75e8f94b93f99a4663a827b33$/',
+            $key
+        );
+    }
+
+    /** @test */
+    public function it_will_generate_keys_using_chosen_unique_strategy()
+    {
+        Config::set('laravel-notification-rate-limit.should_rate_limit_unique_notifications', true);
+        Config::set('laravel-notification-rate-limit.unique_notification_strategy', 'serialize');
+
+        $notification = new TestNotificationWithCustomUniqueAlgorithm();
+        $key = $notification->rateLimitKey($notification, $this->user);
+        $this->assertMatchesRegularExpression(
+            '/^laravelnotificationratelimit\.testnotificationwithcustomuniquealgorithm.(\d+)\.9f528a27c960ee1a6b1fd7db8a9a3694$/',
+            $key
+        );
+    }
+
+    /** @test */
+    public function it_will_error_if_invalid_unique_strategy_chosen()
+    {
+        Config::set('laravel-notification-rate-limit.should_rate_limit_unique_notifications', true);
+        Config::set('laravel-notification-rate-limit.unique_notification_strategy', 'invalid_hash_algo');
+
+        $this->user->notify(new TestNotification());
+
+        // Ensure we are at least logging that there was an issue
+        Log::assertLogged(
+            function (LogEntry $log) {
+                return $log->level === 'warning' &&
+                    str_contains(
+                        $log->message,
+                        'invalid_hash_algo'
+                    );
+            }
+        );
+
+        Event::assertDispatched(NotificationSent::class, function (NotificationSent $evt) {
+            return $evt->notifiable->is($this->user);
+        });
+    }
+
 }

--- a/tests/TestNotificationWithCustomUniqueAlgorithm.php
+++ b/tests/TestNotificationWithCustomUniqueAlgorithm.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Jamesmills\LaravelNotificationRateLimit\Tests;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+use Jamesmills\LaravelNotificationRateLimit\RateLimitedNotification;
+use Jamesmills\LaravelNotificationRateLimit\ShouldRateLimit;
+
+class TestNotificationWithCustomUniqueAlgorithm extends Notification implements ShouldRateLimit
+{
+    use Queueable;
+    use RateLimitedNotification;
+
+    protected $rateLimitUniqueNotificationStrategy = 'md5';
+
+    public function via($notifiable)
+    {
+        return 'mail';
+    }
+
+    public function toMail($notifiable)
+    {
+        return (new MailMessage)
+            ->subject('Hello World!')
+            ->greeting('Hello!')
+            ->line('You must be the world.')
+            ->line('Nice to meet you.');
+    }
+}


### PR DESCRIPTION
Partial resolution to issue #39.  The particular use case was a large notification whose `serialize()`'d cache key was more than 2048 characters long, exceeding the max key length limit of a DynamoDB-based cache.

This PR adds the ability to specify (on either a global or per-notification basis) a mechanism for generating the cache key IDs when determining whether a notification is 'unique'.  

By default, this will use `serialize()` as it has in the past. However, users can also choose to use `md5`, `sha1`, or any other hashing algorithm supported by the PHP install, in case using `serialize()` is not appropriate.  