### PR TITLE
Ensure that $channels (if provided) is passed along when using sendNow()

### DIFF
--- a/src/RateLimitChannelManager.php
+++ b/src/RateLimitChannelManager.php
@@ -27,7 +27,7 @@ class RateLimitChannelManager extends ChannelManager
         if ($notification instanceof ShouldRateLimit) {
             $this->sendWithRateLimitCheck($notifiables, $notification, 'sendNow');
         } else {
-            parent::sendNow($notifiables, $notification);
+            parent::sendNow($notifiables, $notification, $channels);
         }
     }
 

--- a/src/RateLimitChannelManager.php
+++ b/src/RateLimitChannelManager.php
@@ -25,7 +25,7 @@ class RateLimitChannelManager extends ChannelManager
     public function sendNow($notifiables, $notification, array $channels = null): void
     {
         if ($notification instanceof ShouldRateLimit) {
-            $this->sendWithRateLimitCheck($notifiables, $notification, 'sendNow');
+            $this->sendWithRateLimitCheck($notifiables, $notification, 'sendNow', $channels);
         } else {
             parent::sendNow($notifiables, $notification, $channels);
         }
@@ -70,7 +70,7 @@ class RateLimitChannelManager extends ChannelManager
         return true;
     }
 
-    private function sendWithRateLimitCheck($notifiables, $notification, $sending_function): void
+    private function sendWithRateLimitCheck($notifiables, $notification, $sending_function, $channels = null): void
     {
         $notifiables = $this->formatNotifiables($notifiables);
 
@@ -94,7 +94,11 @@ class RateLimitChannelManager extends ChannelManager
                 continue;
             }
 
-            parent::$sending_function($notifiable, $notification);
+            if ($sending_function == "sendNow") {
+                parent::sendNow($notifiable, $notification, $channels);
+            } else {
+                parent::$sending_function($notifiable, $notification);
+            }
         }
     }
 

--- a/src/RateLimitChannelManager.php
+++ b/src/RateLimitChannelManager.php
@@ -94,7 +94,7 @@ class RateLimitChannelManager extends ChannelManager
                 continue;
             }
 
-            if ($sending_function == "sendNow") {
+            if ($sending_function == 'sendNow') {
                 parent::sendNow($notifiable, $notification, $channels);
             } else {
                 parent::$sending_function($notifiable, $notification);

--- a/src/RateLimitChannelManager.php
+++ b/src/RateLimitChannelManager.php
@@ -16,7 +16,7 @@ class RateLimitChannelManager extends ChannelManager
         // If this notification is going to be queued, we do not check for rate limiting
         // until the notification is actually picked up for sending in the queue via sendNow().
         if ($notification instanceof ShouldRateLimit && ! $notification instanceof ShouldQueue) {
-            $this->sendWithRateLimitCheck($notifiables, $notification, 'send');
+            $this->sendWithRateLimitCheck('send', $notifiables, $notification);
         } else {
             parent::send($notifiables, $notification);
         }
@@ -25,7 +25,7 @@ class RateLimitChannelManager extends ChannelManager
     public function sendNow($notifiables, $notification, array $channels = null): void
     {
         if ($notification instanceof ShouldRateLimit) {
-            $this->sendWithRateLimitCheck($notifiables, $notification, 'sendNow', $channels);
+            $this->sendWithRateLimitCheck('sendNow', $notifiables, $notification, $channels);
         } else {
             parent::sendNow($notifiables, $notification, $channels);
         }
@@ -70,7 +70,7 @@ class RateLimitChannelManager extends ChannelManager
         return true;
     }
 
-    private function sendWithRateLimitCheck($notifiables, $notification, $sending_function, $channels = null): void
+    private function sendWithRateLimitCheck($sending_function, $notifiables, $notification, $channels = null): void
     {
         $notifiables = $this->formatNotifiables($notifiables);
 
@@ -97,7 +97,7 @@ class RateLimitChannelManager extends ChannelManager
             if ($sending_function == 'sendNow') {
                 parent::sendNow($notifiable, $notification, $channels);
             } else {
-                parent::$sending_function($notifiable, $notification);
+                parent::send($notifiable, $notification);
             }
         }
     }

--- a/tests/RateLimitTest.php
+++ b/tests/RateLimitTest.php
@@ -426,4 +426,32 @@ class RateLimitTest extends TestCase
             return $evt->notifiable->is($this->user);
         });
     }
+
+    /** @test */
+    public function it_will_sendnow_only_to_requested_channels_nonratelimited()
+    {
+        // By default we try to send to a channel that will fail, if our sendNow
+        // implementation is not respecting the requested channels.
+        $notification = new TestMultichannelNonRateLimitedNotification(['non-existent-channel']);
+
+        $this->user->notifyNow($notification, ['mail']);
+
+        Event::assertDispatched(NotificationSent::class, function (NotificationSent $evt) {
+            return $evt->notifiable->is($this->user) && $evt->channel == 'mail';
+        });
+    }
+
+    /** @test */
+    public function it_will_sendnow_only_to_requested_channels_ratelimited()
+    {
+        // By default we try to send to a channel that will fail, if our sendNow
+        // implementation is not respecting the requested channels.
+        $notification = new TestMultichannelNotification(['non-existent-channel']);
+
+        $this->user->notifyNow($notification, ['mail']);
+
+        Event::assertDispatched(NotificationSent::class, function (NotificationSent $evt) {
+            return $evt->notifiable->is($this->user) && $evt->channel == 'mail';
+        });
+    }
 }

--- a/tests/TestMultichannelNonRateLimitedNotification.php
+++ b/tests/TestMultichannelNonRateLimitedNotification.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Jamesmills\LaravelNotificationRateLimit\Tests;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class TestMultichannelNonRateLimitedNotification extends Notification
+{
+    use Queueable;
+
+    public function __construct(
+        protected array $channels = ['non-existent-channel'],
+    ) {
+    }
+
+    public function via(object $notifiable): array
+    {
+        return $this->channels;
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject('Hello World!')
+            ->greeting('Hello!')
+            ->line('You must be the world.')
+            ->line('Nice to meet you.');
+    }
+}

--- a/tests/TestMultichannelNotification.php
+++ b/tests/TestMultichannelNotification.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Jamesmills\LaravelNotificationRateLimit\Tests;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+use Jamesmills\LaravelNotificationRateLimit\RateLimitedNotification;
+use Jamesmills\LaravelNotificationRateLimit\ShouldRateLimit;
+
+class TestMultichannelNotification extends Notification implements ShouldRateLimit
+{
+    use Queueable;
+    use RateLimitedNotification;
+
+    public function __construct(
+        protected array $channels = ['non-existent-channel'],
+    ) {
+    }
+
+    public function via(object $notifiable): array
+    {
+        return $this->channels;
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject('Hello World!')
+            ->greeting('Hello!')
+            ->line('You must be the world.')
+            ->line('Nice to meet you.');
+    }
+}


### PR DESCRIPTION
Hey @tibbsa 

It was duplicating the notifications when send a notification via multiple channels, due to missing the target channel variable.

Thanks.