### PR TITLE
Fix Implicitly marking parameter warning for php8.4

### DIFF
--- a/src/RateLimitChannelManager.php
+++ b/src/RateLimitChannelManager.php
@@ -22,7 +22,7 @@ class RateLimitChannelManager extends ChannelManager
         }
     }
 
-    public function sendNow($notifiables, $notification, array $channels = null): void
+    public function sendNow($notifiables, $notification, ?array $channels = null): void
     {
         if ($notification instanceof ShouldRateLimit) {
             $this->sendWithRateLimitCheck('sendNow', $notifiables, $notification, $channels);
@@ -70,7 +70,7 @@ class RateLimitChannelManager extends ChannelManager
         return true;
     }
 
-    private function sendWithRateLimitCheck($sending_function, $notifiables, $notification, $channels = null): void
+    private function sendWithRateLimitCheck($sending_function, $notifiables, $notification, ?array $channels = null): void
     {
         $notifiables = $this->formatNotifiables($notifiables);
 


### PR DESCRIPTION
Fix "Implicitly marking parameter $channels as nullable is deprecated, the explicit nullable type must be used instead"