### PR TITLE
Drop Laravel 10 & 11 support (4.0.0)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,19 +13,11 @@ jobs:
       fail-fast: false
       matrix:
         php: [8.2, 8.3, 8.4]
-        laravel: [10.*, 11.*, 12.*, 13.*]
+        laravel: [12.*, 13.*]
         exclude:
           - php: 8.2
             laravel: 13.*
         include:
-          - laravel: 10.*
-            testbench: 8.*
-            phpunit: 10.*
-            logfake: 2.3.0
-          - laravel: 11.*
-            testbench: 9.*
-            phpunit: 11.*
-            logfake: ^2.4
           - laravel: 12.*
             testbench: 10.*
             phpunit: 11.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `laravel-notification-rate-limit` will be documented in this file
 
+## 4.0.0 - 2026-06-13
+
+- Removed support for Laravel 10.x and 11.x. Both have reached end of security support (Laravel 10 in February 2025, Laravel 11 in March 2026); recent framework security advisories are unpatched on those branches, so they can no longer be installed or tested here. Users who still require Laravel 10 or 11 should pin to `3.3.0`, the last release to support them.
+
 ## 3.3.0 - 2026-03-22
 
 - New: Added support for Laravel 13 (PHP 8.3/8.4)

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ Rate Limiting Notifications in Laravel using Laravel's native rate limiter to av
 | 9.x       | 8.0     | 2.1.0                           | 2023-08-26 |
 | 10.x      | 8.0/8.1 | 2.1.0                           | 2023-08-26 |
 | 10.x-13.x | 8.2-8.4 | 3.3.0                           | 2026-03-22 |
+| 12.x-13.x | 8.2-8.4 | 4.0.0                           | 2026-06-13 |
+
+> **Laravel 10 & 11 users:** Laravel 10 (end of security support February 2025) and Laravel 11 (end of security support March 2026) are no longer covered by this package as of `4.0.0`. If you still need Laravel 10 or 11 support, pin to `3.3.0` (`composer require jamesmills/laravel-notification-rate-limit:^3.3`), which is the last release to support them.
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "illuminate/support": "^10.0|^11.0|^12.0|^13.0"
+        "illuminate/support": "^12.0|^13.0"
     },
     "require-dev": {
         "orchestra/testbench": "^10.0|^11.0",


### PR DESCRIPTION
## Summary

Laravel 10 (end of security support **February 2025**) and Laravel 11 (end of security support **March 12, 2026**) are both EOL. Recent `laravel/framework` security advisories were patched on the 12.x/13.x branches but never backported to 10.x or 11.x, and there are no installable patched releases on those branches — nor will there be. Current Composer refuses to even *resolve* advisory-affected versions (`policy.advisories.block`), so the **Laravel 10.\*** and **Laravel 11.\*** CI matrix rows fail at the dependency-install step before tests run. (`COMPOSER_NO_AUDIT=1` only disables the post-install audit, not resolver-level blocking, so it doesn't help.)

The clean fix is to drop both EOL versions. Since this removes supported framework versions, the package is bumped to **4.0.0**, supporting **Laravel 12 and 13** only — the versions still within their security-support windows.

## Changes

- **composer.json** — `illuminate/support: ^12.0|^13.0`
- **.github/workflows/tests.yml** — matrix reduced to Laravel 12 + 13 (PHP 8.2 runs L12; L13 requires PHP 8.3+)
- **README** — add the `4.0.0 → 12.x-13.x` row, keep `3.3.0 → 10.x-13.x` as the historical record, and note that Laravel 10/11 users should pin to `^3.3`
- **CHANGELOG** — document the 4.0.0 removal

## For Laravel 10 / 11 users

`3.3.0` remains the last release supporting Laravel 10 and 11:

```bash
composer require jamesmills/laravel-notification-rate-limit:^3.3
```