### PR TITLE
Add opt-in per-channel rate limiting (issue #50)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to `laravel-notification-rate-limit` will be documented in t
 ## 4.0.0 - 2026-06-13
 
 - Removed support for Laravel 10.x and 11.x. Both have reached end of security support (Laravel 10 in February 2025, Laravel 11 in March 2026); recent framework security advisories are unpatched on those branches, so they can no longer be installed or tested here. Users who still require Laravel 10 or 11 should pin to `3.3.0`, the last release to support them.
+- New: Per-channel rate limiting. Each delivery channel of a notification is rate limited on its own independent counter. The channel being evaluated is passed to `maxAttempts()`, `rateLimitForSeconds()` and `rateLimitKey()`, so a notification can give each channel its own limit, window and cache key, and the channel is exposed on the `NotificationRateLimitReached` event and the skipped-notification log context. (See [issue #50](https://github.com/jamesmills/laravel-notification-rate-limit/issues/50))
+
+  > ⚠️ **Behaviour change — please read.** Per-channel rate limiting is **enabled by default** as of `4.0.0`.
+  >
+  > **What changed.** In earlier versions a single rate-limit counter covered *every* channel a notification was delivered on. Now each channel is counted and limited independently, and the channel name is included in the cache key.
+  >
+  > **Why.** With one shared counter, a notification dispatched to several channels could deliver only the channel that happened to be evaluated first and silently suppress the rest. This was most visible with **queued** notifications, which Laravel dispatches as one job per channel — so the second and later channels were dropped. The ordinary expectation is that every requested channel is delivered, so `4.0.0` makes per-channel counting the default.
+  >
+  > **How to restore the previous behaviour.** Set `'rate_limit_per_channel' => false` in `config/laravel-notification-rate-limit.php` (publish the config first if you have not already), or add `protected $rateLimitPerChannel = false;` to an individual notification.
 
 ## 3.3.0 - 2026-03-22
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ Publish it using the command below.
 php artisan vendor:publish --provider="Jamesmills\LaravelNotificationRateLimit\LaravelNotificationRateLimitServiceProvider"
 ```
 
+## Upgrading from 3.x and below
+
+As of `4.0.0`, notifications are rate limited **per channel by default** — each delivery channel of a notification has its own rate-limit counter, where previously a single counter covered every channel a notification was delivered on. This means a notification dispatched to several channels now reaches all of them, rather than just whichever channel happened to be evaluated first; this is most noticeable for **queued** notifications, where the second and later channels were previously suppressed.
+
+To restore the previous behaviour, set `rate_limit_per_channel` to `false` in the config, or add `protected $rateLimitPerChannel = false;` to an individual notification. See the [CHANGELOG](CHANGELOG.md) and [Rate limiting per channel](#rate-limiting-per-channel) for full details.
+
 ## Upgrading from 2.x
 
 If you are upgrading from version 2, be aware that the `NotificationRateLimitReached` event signature has changed, and now includes more information about the notification being skipped. If you have implemented your own version of this event class, you will need to update the constructor signature to accept these additional parameters. No other changes should be required as a part of the upgrade process.
@@ -99,6 +105,56 @@ Update for an individual basis by adding the below to the Notification:
 // Change rate limit to 1 hour
 protected $rateLimitForSeconds = 3600;
 ```
+
+### Rate limiting per channel
+
+As of `4.0.0`, **each delivery channel of a notification is rate limited independently by default** — every channel has its own counter, so reaching the limit on one channel does not suppress the others. (This is a behaviour change in v4; see the [CHANGELOG](CHANGELOG.md) for the rationale and upgrade notes.)
+
+If you prefer the previous behaviour — a single counter covering every channel a notification is delivered on — disable it globally with the `rate_limit_per_channel` config setting, or per notification:
+
+```php
+// Opt this notification out of per-channel rate limiting
+protected $rateLimitPerChannel = false;
+```
+
+Per-channel rate limiting has two parts:
+
+**1. Independent counters — the default.** Each channel is tracked on its own counter, so every channel is delivered the first time and throttled separately thereafter. This is what lets a notification sent to several channels reach all of them rather than just the first. It matters most for **queued** notifications: Laravel queues one job per channel, so before v4 a queued multi-channel notification (sharing one counter) delivered only its first channel and suppressed the rest.
+
+**2. Different limits per channel — optional.** The channel being evaluated is passed to `maxAttempts()` and `rateLimitForSeconds()`, so you can override them to give each channel its own limit. Override only what you need; any channel you don't special-case falls back to the global config:
+
+```php
+// Five broadcasts per minute; every other channel keeps the configured default.
+public function maxAttempts(?string $channel = null): int
+{
+    return $channel === 'broadcast'
+        ? 5
+        : config('laravel-notification-rate-limit.max_attempts');
+}
+
+// One mail per hour, one broadcast per minute, config default for the rest.
+public function rateLimitForSeconds(?string $channel = null): int
+{
+    return match ($channel) {
+        'mail'      => 3600,
+        'broadcast' => 60,
+        default     => config('laravel-notification-rate-limit.rate_limit_seconds'),
+    };
+}
+```
+
+The channel is likewise passed to `rateLimitKey()` as a third argument, so you can build channel-aware cache keys:
+
+```php
+public function rateLimitKey($notification, $notifiable, ?string $channel = null): string
+{
+    // ... your custom key, optionally incorporating $channel ...
+}
+```
+
+The channel is also exposed on the `NotificationRateLimitReached` event (the `$channel` property) and included in the skipped-notification log context. If you disable per-channel limiting (the whole-notification mode), the `$channel` argument to all of these is `null`.
+
+> **Note:** With per-channel limiting each channel is delivered as its own send, so Laravel assigns a distinct notification id per channel. In the whole-notification (opt-out) mode, all channels of a single send share one id. This only matters if you correlate channels by notification id (for example, across `database`-channel rows).
     
 ### Logging skipped notifications
 

--- a/config/config.php
+++ b/config/config.php
@@ -99,4 +99,24 @@ return [
     */
 
     'event' => \Jamesmills\LaravelNotificationRateLimit\Events\NotificationRateLimitReached::class,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Rate Limit Per Channel
+    |--------------------------------------------------------------------------
+    |
+    | Each delivery channel of a notification is, by default, rate limited on
+    | its own independent counter, so that reaching the limit on one channel
+    | (for example `mail`) does not suppress the others (for example
+    | `broadcast`). The channel is passed to maxAttempts(), rateLimitForSeconds()
+    | and rateLimitKey(), so a notification may override those to give each
+    | channel its own limit, window or cache key.
+    |
+    | Set this to false to restore the pre-4.0.0 behaviour, where a single
+    | counter covers every channel a notification is delivered on. This can also
+    | be overridden per-notification with a `$rateLimitPerChannel` property.
+    |
+    */
+
+    'rate_limit_per_channel' => true,
 ];

--- a/src/RateLimitChannelManager.php
+++ b/src/RateLimitChannelManager.php
@@ -31,11 +31,11 @@ class RateLimitChannelManager extends ChannelManager
         }
     }
 
-    private function checkRateLimit($notifiable, $notification): bool
+    private function checkRateLimit($notifiable, $notification, ?string $channel = null): bool
     {
-        $key = $notification->rateLimitKey($notification, $notifiable);
+        $key = $notification->rateLimitKey($notification, $notifiable, $channel);
 
-        if ($notification->limiter()->tooManyAttempts($key, $notification->maxAttempts())) {
+        if ($notification->limiter()->tooManyAttempts($key, $notification->maxAttempts($channel))) {
             $limitReason = NotificationRateLimitReached::REASON_LIMITER;
         } else {
             $limitReason = $notification->rateLimitCheckDiscard($key);
@@ -48,7 +48,8 @@ class RateLimitChannelManager extends ChannelManager
                 $notifiable,
                 $key,
                 $notification->limiter()->availableIn($key),
-                $limitReason
+                $limitReason,
+                $channel
             );
 
             event($event);
@@ -59,13 +60,14 @@ class RateLimitChannelManager extends ChannelManager
                     'reason' => $event->reason,
                     'availableIn' => $event->availableIn,
                     'key' => $event->key,
+                    'channel' => $channel,
                 ]);
             }
 
             return false;
         }
 
-        $notification->limiter()->hit($key, $notification->rateLimitForSeconds());
+        $notification->limiter()->hit($key, $notification->rateLimitForSeconds($channel));
 
         return true;
     }
@@ -74,23 +76,30 @@ class RateLimitChannelManager extends ChannelManager
     {
         $notifiables = $this->formatNotifiables($notifiables);
 
-        // Send each notification, but protect against the possibility that the
-        // rate limiter itself might fail (e.g. due to the cache service not being
-        // available, or refusing to accept a cache key).  If our own
-        // rate limiting logic fails for some reason, we send the notification anyway.
         foreach ($notifiables as $notifiable) {
-            $sending_permitted = true;
+            // Per-channel mode: resolve the channels for this notifiable and
+            // evaluate the rate limiter once per channel, delivering each channel
+            // on its own counter. Explicitly requested channels win over via().
+            if ($notification->rateLimitPerChannel()) {
+                $viaChannels = $channels ?: $notification->via($notifiable);
 
-            try {
-                $sending_permitted = $this->checkRateLimit($notifiable, $notification);
-            } catch (\Exception $e) {
-                $notification_type = get_class($notifiable);
+                if (empty($viaChannels)) {
+                    continue;
+                }
 
-                logger()->warning('Notification rate limiter encountered an internal exception (notification type: '.$notification_type.'); bypassing limiter. Error: '.$e->getMessage());
-                report($e);
+                foreach ((array) $viaChannels as $channel) {
+                    if ($this->rateLimitPermitsSending($notifiable, $notification, $channel)) {
+                        // A non-queued send() is equivalent to an immediate
+                        // single-channel sendNow(), so both paths deliver here.
+                        parent::sendNow($notifiable, $notification, [$channel]);
+                    }
+                }
+
+                continue;
             }
 
-            if (! $sending_permitted) {
+            // Default mode: a single channel-agnostic check covers all channels.
+            if (! $this->rateLimitPermitsSending($notifiable, $notification, null)) {
                 continue;
             }
 
@@ -99,6 +108,25 @@ class RateLimitChannelManager extends ChannelManager
             } else {
                 parent::send($notifiable, $notification);
             }
+        }
+    }
+
+    /**
+     * Run the rate-limit check, protecting against the possibility that the
+     * limiter itself fails (e.g. the cache backend is unavailable or rejects the
+     * key). If our own limiting logic throws, we log/report and send anyway.
+     */
+    private function rateLimitPermitsSending($notifiable, $notification, ?string $channel = null): bool
+    {
+        try {
+            return $this->checkRateLimit($notifiable, $notification, $channel);
+        } catch (\Exception $e) {
+            $notification_type = get_class($notifiable);
+
+            logger()->warning('Notification rate limiter encountered an internal exception (notification type: '.$notification_type.'); bypassing limiter. Error: '.$e->getMessage());
+            report($e);
+
+            return true;
         }
     }
 

--- a/src/RateLimitedNotification.php
+++ b/src/RateLimitedNotification.php
@@ -10,7 +10,7 @@ use Illuminate\Support\Str;
  */
 trait RateLimitedNotification
 {
-    public function rateLimitKey($notification, $notifiable): string
+    public function rateLimitKey($notification, $notifiable, ?string $channel = null): string
     {
         $parts = array_merge(
             [
@@ -18,6 +18,7 @@ trait RateLimitedNotification
                 class_basename($notification),
                 $this->determineNotifiableIdentifier($notifiable),
             ],
+            $channel !== null ? [$channel] : [],
             $this->rateLimitCustomCacheKeyParts(),
             $this->rateLimitUniqueueNotifications($notification)
         );
@@ -66,9 +67,13 @@ trait RateLimitedNotification
     /**
      * Max attempts to accept in the throttled timeframe.
      *
+     * In per-channel mode the channel being evaluated is passed in, so this may
+     * be overridden to return a different limit per channel. The default
+     * implementation applies the same limit to every channel.
+     *
      * @return \Illuminate\Config\Repository|mixed
      */
-    public function maxAttempts()
+    public function maxAttempts(?string $channel = null)
     {
         return $this->maxAttempts ?? config('laravel-notification-rate-limit.max_attempts');
     }
@@ -76,9 +81,13 @@ trait RateLimitedNotification
     /**
      * Time in seconds to throttle the notifications.
      *
+     * In per-channel mode the channel being evaluated is passed in, so this may
+     * be overridden to return a different window per channel. The default
+     * implementation applies the same window to every channel.
+     *
      * @return \Illuminate\Config\Repository|mixed
      */
-    public function rateLimitForSeconds()
+    public function rateLimitForSeconds(?string $channel = null)
     {
         return $this->rateLimitForSeconds ?? config('laravel-notification-rate-limit.rate_limit_seconds');
     }
@@ -91,6 +100,17 @@ trait RateLimitedNotification
     public function logSkippedNotifications()
     {
         return $this->logSkippedNotifications ?? config('laravel-notification-rate-limit.log_skipped_notifications');
+    }
+
+    /**
+     * Whether rate limiting is evaluated independently per notification
+     * channel rather than once for the whole notification.
+     *
+     * @return \Illuminate\Config\Repository|mixed
+     */
+    public function rateLimitPerChannel()
+    {
+        return $this->rateLimitPerChannel ?? config('laravel-notification-rate-limit.rate_limit_per_channel');
     }
 
     public function shouldRateLimitUniqueNotifications()

--- a/tests/RateLimitTest.php
+++ b/tests/RateLimitTest.php
@@ -51,10 +51,11 @@ class RateLimitTest extends TestCase
         Event::fake();
         Log::swap(new LogFake);
 
-        // When Notification is faked, Notification::send() and Notification::route
-        // do not call our channel manager, so we cannot use the Notification tests to
-        // verify that m
-        // that works, Notification::send()/route() will work in a live application.
+        // Notification::fake() swaps the channel manager binding, so Notification::send()
+        // and Notification::route() would otherwise bypass our RateLimitChannelManager.
+        // Rebinding the real RateLimitChannelManager below ensures $user->notify(),
+        // notifyNow(), and direct $this->rateLimitChannelManager calls exercise the
+        // actual rate-limiting code path.
         $this->app->singleton(ChannelManager::class, function ($app) {
             return new RateLimitChannelManager($app);
         });
@@ -270,12 +271,13 @@ class RateLimitTest extends TestCase
         );
 
         // Send a second notification and expect it to fail. Verify that
-        // the cache key in use included the 'customKey' value.
+        // the cache key in use included the 'customKey' value. Per-channel
+        // limiting is on by default, so the key also includes the channel.
         $this->customRateLimitKeyUser->notify(new TestNotification());
         Event::assertDispatched(NotificationRateLimitReached::class);
         Log::assertLogged(
             function (LogEntry $log) {
-                $expected_key = Str::lower(config('laravel-notification-rate-limit.key_prefix').'.TestNotification.customKey');
+                $expected_key = Str::lower(config('laravel-notification-rate-limit.key_prefix').'.TestNotification.customKey.mail');
 
                 return $log->context['key'] === $expected_key;
             }
@@ -301,7 +303,7 @@ class RateLimitTest extends TestCase
             function (NotificationRateLimitReached $event) {
                 return ($event->notification instanceof TestNotification)
                     && ($event->notifiable->id === $this->customRateLimitKeyUser->id)
-                    && ($event->key === Str::lower(config('laravel-notification-rate-limit.key_prefix').'.TestNotification.customKey'))
+                    && ($event->key === Str::lower(config('laravel-notification-rate-limit.key_prefix').'.TestNotification.customKey.mail'))
                     && ($event->reason === NotificationRateLimitReached::REASON_LIMITER);
             }
         );
@@ -453,5 +455,330 @@ class RateLimitTest extends TestCase
         Event::assertDispatched(NotificationSent::class, function (NotificationSent $evt) {
             return $evt->notifiable->is($this->user) && $evt->channel == 'mail';
         });
+    }
+
+    #[Test]
+    public function rate_limit_key_without_channel_matches_legacy_format()
+    {
+        $notification = new TestNotification();
+
+        $key = $notification->rateLimitKey($notification, $this->user);
+
+        $expected = Str::lower(
+            config('laravel-notification-rate-limit.key_prefix')
+            .'.TestNotification.'.$this->user->getKey()
+        );
+
+        $this->assertSame($expected, $key);
+    }
+
+    #[Test]
+    public function rate_limit_key_includes_channel_when_provided()
+    {
+        $notification = new TestNotification();
+
+        $key = $notification->rateLimitKey($notification, $this->user, 'mail');
+
+        $expected = Str::lower(
+            config('laravel-notification-rate-limit.key_prefix')
+            .'.TestNotification.'.$this->user->getKey().'.mail'
+        );
+
+        $this->assertSame($expected, $key);
+    }
+
+    #[Test]
+    public function rate_limit_key_differs_between_channels()
+    {
+        $notification = new TestNotification();
+
+        $this->assertNotSame(
+            $notification->rateLimitKey($notification, $this->user, 'mail'),
+            $notification->rateLimitKey($notification, $this->user, 'broadcast')
+        );
+    }
+
+    #[Test]
+    public function per_channel_defaults_to_config_value()
+    {
+        Config::set('laravel-notification-rate-limit.rate_limit_per_channel', false);
+        $this->assertFalse((new TestNotification())->rateLimitPerChannel());
+
+        Config::set('laravel-notification-rate-limit.rate_limit_per_channel', true);
+        $this->assertTrue((new TestNotification())->rateLimitPerChannel());
+    }
+
+    #[Test]
+    public function per_channel_property_overrides_config()
+    {
+        Config::set('laravel-notification-rate-limit.rate_limit_per_channel', false);
+
+        // The property is true on this notification, overriding the false config.
+        $this->assertTrue((new TestPerChannelPropertyNotification())->rateLimitPerChannel());
+    }
+
+    #[Test]
+    public function per_channel_property_false_overrides_config_true()
+    {
+        Config::set('laravel-notification-rate-limit.rate_limit_per_channel', true);
+
+        // An explicit false on the notification beats config=true.
+        $this->assertFalse((new TestPerChannelDisabledNotification())->rateLimitPerChannel());
+    }
+
+    #[Test]
+    public function rate_limit_reached_event_defaults_channel_to_null()
+    {
+        $event = new NotificationRateLimitReached(
+            new TestNotification(),
+            $this->user,
+            'some-key',
+            10,
+            NotificationRateLimitReached::REASON_LIMITER
+        );
+
+        $this->assertNull($event->channel);
+    }
+
+    #[Test]
+    public function rate_limit_reached_event_exposes_channel()
+    {
+        $event = new NotificationRateLimitReached(
+            new TestNotification(),
+            $this->user,
+            'some-key',
+            10,
+            NotificationRateLimitReached::REASON_LIMITER,
+            'mail'
+        );
+
+        $this->assertSame('mail', $event->channel);
+    }
+
+    #[Test]
+    public function per_channel_mode_limits_each_channel_independently()
+    {
+        Config::set('laravel-notification-rate-limit.rate_limit_per_channel', true);
+
+        // First send: both channels deliver, no rate-limit events.
+        $this->rateLimitChannelManager->send($this->user, new TestMultiDeliverableNotification());
+        Event::assertDispatchedTimes(NotificationSent::class, 2);
+        Event::assertNotDispatched(NotificationRateLimitReached::class);
+
+        // Second identical send within the window: each channel is limited
+        // independently, so two rate-limit events and no further deliveries.
+        $this->rateLimitChannelManager->send($this->user, new TestMultiDeliverableNotification());
+        Event::assertDispatchedTimes(NotificationSent::class, 2);
+        Event::assertDispatchedTimes(NotificationRateLimitReached::class, 2);
+    }
+
+    #[Test]
+    public function whole_notification_mode_rate_limits_as_a_whole()
+    {
+        // Opt out of the per-channel default to exercise the legacy
+        // whole-notification behaviour (a single counter for all channels).
+        Config::set('laravel-notification-rate-limit.rate_limit_per_channel', false);
+
+        $this->rateLimitChannelManager->send($this->user, new TestMultiDeliverableNotification());
+        Event::assertDispatchedTimes(NotificationSent::class, 2);
+        Event::assertNotDispatched(NotificationRateLimitReached::class);
+
+        // Second send: the whole notification is limited (one event), nothing delivered.
+        $this->rateLimitChannelManager->send($this->user, new TestMultiDeliverableNotification());
+        Event::assertDispatchedTimes(NotificationSent::class, 2);
+        Event::assertDispatchedTimes(NotificationRateLimitReached::class, 1);
+    }
+
+    #[Test]
+    public function per_channel_mode_allows_each_channel_when_sent_separately()
+    {
+        // Simulates Laravel's queued delivery, which splits a multichannel
+        // notification into one sendNow() call per channel.
+        Config::set('laravel-notification-rate-limit.rate_limit_per_channel', true);
+
+        $this->rateLimitChannelManager->sendNow($this->user, new TestMultiDeliverableNotification(), ['mail']);
+        $this->rateLimitChannelManager->sendNow($this->user, new TestMultiDeliverableNotification(), [TestSecondChannel::class]);
+
+        Event::assertDispatchedTimes(NotificationSent::class, 2);
+        Event::assertNotDispatched(NotificationRateLimitReached::class);
+    }
+
+    #[Test]
+    public function whole_notification_mode_suppresses_second_channel_when_sent_separately()
+    {
+        // Documents the legacy (opt-out) behaviour that the per-channel default
+        // now avoids: with a single channel-agnostic counter, splitting the send
+        // (as the queue does) suppresses every channel after the first.
+        Config::set('laravel-notification-rate-limit.rate_limit_per_channel', false);
+
+        $this->rateLimitChannelManager->sendNow($this->user, new TestMultiDeliverableNotification(), ['mail']);
+        $this->rateLimitChannelManager->sendNow($this->user, new TestMultiDeliverableNotification(), [TestSecondChannel::class]);
+
+        Event::assertDispatchedTimes(NotificationSent::class, 1);
+        Event::assertDispatchedTimes(NotificationRateLimitReached::class, 1);
+    }
+
+    #[Test]
+    public function per_channel_mode_includes_channel_in_event_and_log()
+    {
+        Config::set('laravel-notification-rate-limit.rate_limit_per_channel', true);
+
+        // Prime the 'mail' channel limiter.
+        $this->rateLimitChannelManager->sendNow($this->user, new TestMultiDeliverableNotification(), ['mail']);
+
+        // Second send on 'mail' is limited; event + log should name the channel.
+        $this->rateLimitChannelManager->sendNow($this->user, new TestMultiDeliverableNotification(), ['mail']);
+
+        Event::assertDispatched(
+            NotificationRateLimitReached::class,
+            fn (NotificationRateLimitReached $e) => $e->channel === 'mail'
+        );
+        Log::assertLogged(
+            fn (LogEntry $log) => $log->level === 'notice'
+                && array_key_exists('channel', $log->context)
+                && $log->context['channel'] === 'mail'
+        );
+    }
+
+    #[Test]
+    public function whole_notification_mode_leaves_event_channel_null()
+    {
+        // In the opt-out (whole-notification) mode there is no per-channel
+        // context, so the event channel and log context are null.
+        Config::set('laravel-notification-rate-limit.rate_limit_per_channel', false);
+
+        $this->user->notify(new TestNotification());
+        $this->user->notify(new TestNotification());
+
+        Event::assertDispatched(
+            NotificationRateLimitReached::class,
+            fn (NotificationRateLimitReached $e) => $e->channel === null
+        );
+        Log::assertLogged(
+            fn (LogEntry $log) => $log->level === 'notice'
+                && array_key_exists('channel', $log->context)
+                && $log->context['channel'] === null
+        );
+    }
+
+    #[Test]
+    public function per_channel_mode_respects_explicitly_requested_channels()
+    {
+        Config::set('laravel-notification-rate-limit.rate_limit_per_channel', true);
+
+        // via() would include a non-existent channel; requesting ['mail'] must win.
+        $notification = new TestMultichannelNotification(['non-existent-channel']);
+
+        $this->user->notifyNow($notification, ['mail']);
+
+        Event::assertDispatched(
+            NotificationSent::class,
+            fn (NotificationSent $evt) => $evt->notifiable->is($this->user) && $evt->channel === 'mail'
+        );
+        Event::assertNotDispatched(NotificationRateLimitReached::class);
+    }
+
+    #[Test]
+    public function legacy_two_parameter_rate_limit_key_override_still_works()
+    {
+        Config::set('laravel-notification-rate-limit.rate_limit_per_channel', true);
+
+        // First send succeeds and must not error despite the manager passing a
+        // third $channel argument to the two-parameter override.
+        $this->user->notify(new TestLegacyKeyNotification());
+        Event::assertDispatched(NotificationSent::class);
+        Event::assertNotDispatched(NotificationRateLimitReached::class);
+
+        // Second send is limited using the user's custom (channel-agnostic) key.
+        $this->user->notify(new TestLegacyKeyNotification());
+        Event::assertDispatched(
+            NotificationRateLimitReached::class,
+            fn (NotificationRateLimitReached $e) => $e->key === 'legacy-key-'.$this->user->getKey()
+        );
+    }
+
+    #[Test]
+    public function custom_event_class_with_legacy_constructor_still_works()
+    {
+        // A user-provided event class predating the $channel argument has only
+        // five constructor parameters. The manager always constructs the event
+        // with six positional args; PHP ignores the extra one, so old custom
+        // event classes keep working.
+        Config::set('laravel-notification-rate-limit.event', TestLegacyEventWithoutChannel::class);
+
+        // Trigger a rate limit (second send) and confirm the custom event is
+        // constructed and dispatched without error.
+        $this->user->notify(new TestNotification());
+        $this->user->notify(new TestNotification());
+
+        Event::assertDispatched(TestLegacyEventWithoutChannel::class);
+    }
+
+    #[Test]
+    public function per_channel_mode_supports_different_max_attempts_per_channel()
+    {
+        // mail allows 1 attempt; the second channel allows 2.
+        $this->rateLimitChannelManager->send($this->user, new TestPerChannelMaxAttemptsNotification());
+        Event::assertDispatchedTimes(NotificationSent::class, 2);
+        Event::assertNotDispatched(NotificationRateLimitReached::class);
+
+        // Second send: mail is now over its limit (1), the second channel is not (2).
+        $this->rateLimitChannelManager->send($this->user, new TestPerChannelMaxAttemptsNotification());
+        Event::assertDispatchedTimes(NotificationSent::class, 3);
+        Event::assertDispatchedTimes(NotificationRateLimitReached::class, 1);
+        Event::assertDispatched(
+            NotificationRateLimitReached::class,
+            fn (NotificationRateLimitReached $e) => $e->channel === 'mail'
+        );
+
+        // Third send: both channels are now over their limits.
+        $this->rateLimitChannelManager->send($this->user, new TestPerChannelMaxAttemptsNotification());
+        Event::assertDispatchedTimes(NotificationSent::class, 3);
+        Event::assertDispatchedTimes(NotificationRateLimitReached::class, 3);
+    }
+
+    #[Test]
+    public function per_channel_mode_supports_different_windows_per_channel()
+    {
+        // mail is throttled for 3600s; the second channel for only 30s.
+        $this->rateLimitChannelManager->send($this->user, new TestPerChannelWindowNotification());
+        Event::assertNotDispatched(NotificationRateLimitReached::class);
+
+        // Second send: both are limited, but each reports its own window via availableIn.
+        $this->rateLimitChannelManager->send($this->user, new TestPerChannelWindowNotification());
+
+        Event::assertDispatched(
+            NotificationRateLimitReached::class,
+            fn (NotificationRateLimitReached $e) => $e->channel === 'mail' && $e->availableIn > 1000
+        );
+        Event::assertDispatched(
+            NotificationRateLimitReached::class,
+            fn (NotificationRateLimitReached $e) => $e->channel === TestSecondChannel::class
+                && $e->availableIn > 0 && $e->availableIn <= 30
+        );
+    }
+
+    #[Test]
+    public function legacy_zero_parameter_max_attempts_override_still_works()
+    {
+        // The manager calls maxAttempts($channel); a zero-parameter override
+        // must still work (PHP ignores the extra argument).
+        $this->rateLimitChannelManager->send($this->user, new TestLegacyMaxAttemptsNotification());
+        Event::assertDispatched(NotificationSent::class);
+        Event::assertNotDispatched(NotificationRateLimitReached::class);
+
+        // Second send is limited using the override's value of 1.
+        $this->rateLimitChannelManager->send($this->user, new TestLegacyMaxAttemptsNotification());
+        Event::assertDispatched(NotificationRateLimitReached::class);
+    }
+
+    #[Test]
+    public function per_channel_is_enabled_by_default()
+    {
+        // As of 4.0.0 the package ships with per-channel rate limiting on by
+        // default (see the CHANGELOG). setUp() does not override this key, so
+        // this reflects the shipped package default.
+        $this->assertTrue(config('laravel-notification-rate-limit.rate_limit_per_channel'));
+        $this->assertTrue((new TestNotification())->rateLimitPerChannel());
     }
 }

--- a/tests/TestLegacyEventWithoutChannel.php
+++ b/tests/TestLegacyEventWithoutChannel.php
@@ -1,16 +1,18 @@
 <?php
 
-namespace Jamesmills\LaravelNotificationRateLimit\Events;
+namespace Jamesmills\LaravelNotificationRateLimit\Tests;
 
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Notifications\Notification;
 use Illuminate\Queue\SerializesModels;
 
-class NotificationRateLimitReached
+// Mirrors the pre-4.0.0 NotificationRateLimitReached signature (no $channel).
+// Used to prove that a custom event class with the old five-parameter
+// constructor still works when the manager constructs it with the new sixth
+// ($channel) argument (PHP ignores the extra positional argument).
+class TestLegacyEventWithoutChannel
 {
-    public const REASON_LIMITER = 'Rate limit reached';
-
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
     public function __construct(
@@ -19,7 +21,6 @@ class NotificationRateLimitReached
         public string $key,
         public int $availableIn,
         public string $reason,
-        public ?string $channel = null,
     ) {
     }
 }

--- a/tests/TestLegacyKeyNotification.php
+++ b/tests/TestLegacyKeyNotification.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Jamesmills\LaravelNotificationRateLimit\Tests;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+use Jamesmills\LaravelNotificationRateLimit\RateLimitedNotification;
+use Jamesmills\LaravelNotificationRateLimit\ShouldRateLimit;
+
+class TestLegacyKeyNotification extends Notification implements ShouldRateLimit
+{
+    use Queueable;
+    use RateLimitedNotification;
+
+    public function via($notifiable)
+    {
+        return 'mail';
+    }
+
+    public function toMail($notifiable)
+    {
+        return (new MailMessage)
+            ->subject('Hello World!')
+            ->line('You must be the world.');
+    }
+
+    // Legacy two-parameter override (pre-dates the $channel argument). The
+    // manager now calls rateLimitKey() with three arguments; PHP passes the
+    // extra argument harmlessly to this two-parameter method.
+    public function rateLimitKey($notification, $notifiable): string
+    {
+        return 'legacy-key-'.$notifiable->getKey();
+    }
+}

--- a/tests/TestLegacyMaxAttemptsNotification.php
+++ b/tests/TestLegacyMaxAttemptsNotification.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Jamesmills\LaravelNotificationRateLimit\Tests;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+use Jamesmills\LaravelNotificationRateLimit\RateLimitedNotification;
+use Jamesmills\LaravelNotificationRateLimit\ShouldRateLimit;
+
+// Legacy zero-parameter maxAttempts() override (pre-dates the $channel
+// argument). The manager now calls maxAttempts($channel); PHP passes the extra
+// argument harmlessly to this zero-parameter method.
+class TestLegacyMaxAttemptsNotification extends Notification implements ShouldRateLimit
+{
+    use Queueable;
+    use RateLimitedNotification;
+
+    protected $rateLimitPerChannel = true;
+
+    public function via($notifiable)
+    {
+        return 'mail';
+    }
+
+    public function toMail($notifiable)
+    {
+        return (new MailMessage)
+            ->subject('Hello World!')
+            ->line('You must be the world.');
+    }
+
+    public function maxAttempts()
+    {
+        return 1;
+    }
+}

--- a/tests/TestMultiDeliverableNotification.php
+++ b/tests/TestMultiDeliverableNotification.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Jamesmills\LaravelNotificationRateLimit\Tests;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+use Jamesmills\LaravelNotificationRateLimit\RateLimitedNotification;
+use Jamesmills\LaravelNotificationRateLimit\ShouldRateLimit;
+
+class TestMultiDeliverableNotification extends Notification implements ShouldRateLimit
+{
+    use Queueable;
+    use RateLimitedNotification;
+
+    public function via($notifiable)
+    {
+        return ['mail', TestSecondChannel::class];
+    }
+
+    public function toMail($notifiable)
+    {
+        return (new MailMessage)
+            ->subject('Hello World!')
+            ->line('You must be the world.');
+    }
+}

--- a/tests/TestPerChannelDisabledNotification.php
+++ b/tests/TestPerChannelDisabledNotification.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Jamesmills\LaravelNotificationRateLimit\Tests;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+use Jamesmills\LaravelNotificationRateLimit\RateLimitedNotification;
+use Jamesmills\LaravelNotificationRateLimit\ShouldRateLimit;
+
+class TestPerChannelDisabledNotification extends Notification implements ShouldRateLimit
+{
+    use Queueable;
+    use RateLimitedNotification;
+
+    protected $rateLimitPerChannel = false;
+
+    public function via($notifiable)
+    {
+        return 'mail';
+    }
+
+    public function toMail($notifiable)
+    {
+        return (new MailMessage)
+            ->subject('Hello World!')
+            ->line('You must be the world.');
+    }
+}

--- a/tests/TestPerChannelMaxAttemptsNotification.php
+++ b/tests/TestPerChannelMaxAttemptsNotification.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jamesmills\LaravelNotificationRateLimit\Tests;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+use Jamesmills\LaravelNotificationRateLimit\RateLimitedNotification;
+use Jamesmills\LaravelNotificationRateLimit\ShouldRateLimit;
+
+// Per-channel notification that allows a different number of attempts per
+// channel: one mail, but two on the second channel.
+class TestPerChannelMaxAttemptsNotification extends Notification implements ShouldRateLimit
+{
+    use Queueable;
+    use RateLimitedNotification;
+
+    protected $rateLimitPerChannel = true;
+
+    public function via($notifiable)
+    {
+        return ['mail', TestSecondChannel::class];
+    }
+
+    public function toMail($notifiable)
+    {
+        return (new MailMessage)
+            ->subject('Hello World!')
+            ->line('You must be the world.');
+    }
+
+    public function maxAttempts(?string $channel = null)
+    {
+        return $channel === TestSecondChannel::class ? 2 : 1;
+    }
+}

--- a/tests/TestPerChannelPropertyNotification.php
+++ b/tests/TestPerChannelPropertyNotification.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Jamesmills\LaravelNotificationRateLimit\Tests;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+use Jamesmills\LaravelNotificationRateLimit\RateLimitedNotification;
+use Jamesmills\LaravelNotificationRateLimit\ShouldRateLimit;
+
+class TestPerChannelPropertyNotification extends Notification implements ShouldRateLimit
+{
+    use Queueable;
+    use RateLimitedNotification;
+
+    protected $rateLimitPerChannel = true;
+
+    public function via($notifiable)
+    {
+        return 'mail';
+    }
+
+    public function toMail($notifiable)
+    {
+        return (new MailMessage)
+            ->subject('Hello World!')
+            ->line('You must be the world.');
+    }
+}

--- a/tests/TestPerChannelWindowNotification.php
+++ b/tests/TestPerChannelWindowNotification.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Jamesmills\LaravelNotificationRateLimit\Tests;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+use Jamesmills\LaravelNotificationRateLimit\RateLimitedNotification;
+use Jamesmills\LaravelNotificationRateLimit\ShouldRateLimit;
+
+// Per-channel notification that throttles each channel for a different length
+// of time: an hour for mail, thirty seconds for the second channel.
+class TestPerChannelWindowNotification extends Notification implements ShouldRateLimit
+{
+    use Queueable;
+    use RateLimitedNotification;
+
+    protected $rateLimitPerChannel = true;
+
+    public function via($notifiable)
+    {
+        return ['mail', TestSecondChannel::class];
+    }
+
+    public function toMail($notifiable)
+    {
+        return (new MailMessage)
+            ->subject('Hello World!')
+            ->line('You must be the world.');
+    }
+
+    public function rateLimitForSeconds(?string $channel = null)
+    {
+        return $channel === 'mail' ? 3600 : 30;
+    }
+}

--- a/tests/TestSecondChannel.php
+++ b/tests/TestSecondChannel.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Jamesmills\LaravelNotificationRateLimit\Tests;
+
+use Illuminate\Notifications\Notification;
+
+class TestSecondChannel
+{
+    public function send($notifiable, Notification $notification)
+    {
+        // No-op test channel: lets a second channel "deliver" so that a
+        // NotificationSent event fires without external infrastructure.
+        return null;
+    }
+}


### PR DESCRIPTION
Closes #50.

## Summary

Adds an **opt-in** mode that rate-limits notifications independently per delivery channel. Default behaviour is unchanged.

- **`rate_limit_per_channel` config** (default `false`) and a per-notification **`protected $rateLimitPerChannel`** override (mirrors the existing `logSkippedNotifications()` / `shouldRateLimitUniqueNotifications()` accessor pattern).
- **`RateLimitChannelManager`** — when enabled, resolves `$channels ?: via()` per notifiable and checks/sends each channel on its own counter via `parent::sendNow($notifiable, $n, [$channel])`; the limiter-failure "send anyway" guard is centralised in `rateLimitPermitsSending()` and applied per channel. The default path is untouched.
- **Channel-aware hooks.** The channel being evaluated is passed to `rateLimitKey()`, `maxAttempts()` and `rateLimitForSeconds()` (all gain an optional `?string $channel = null`, `null` in default mode), and is exposed on the `NotificationRateLimitReached` event + skipped-notification log context.

### Two layers (made explicit in the README)

Per-channel mode delivers two distinct things:

1. **Independent counters — automatic.** Each channel is tracked separately, so reaching the limit on one channel no longer suppresses the others. This also fixes a latent interaction with **queued** notifications: Laravel queues one job per channel, each re-entering `sendNow($notifiable, $n, [oneChannel])`; under the old channel-agnostic key the first channel's hit suppressed the rest.
2. **Different limit *values* per channel — optional.** Override `maxAttempts()` / `rateLimitForSeconds()` (which now receive `$channel`) to give each channel its own attempt count and window — e.g. one mail per hour but five broadcasts per minute. Un-overridden channels fall back to the global config.

### Backwards compatibility

Non-breaking and intentionally **default-off**, so existing behaviour does not change. With the feature off, cache keys, limit values and limiting decisions are identical to before. The `ShouldRateLimit` interface is deliberately left at its original signatures (the new `$channel` args are trait-provided, like the other accessors). Tests prove a pre-existing 2-param `rateLimitKey` override, a 0-param `maxAttempts` override, and a legacy 5-parameter custom `event` class all keep working when called with the new extra argument.

## Test Plan

- [x] `composer test` green — **38 tests, 114 assertions**
- [x] Default-mode parity: multichannel notification limited as a whole; keys/values/semantics unchanged
- [x] Independent counters: each channel delivers first, limited independently after (incl. simulated queued split)
- [x] Per-channel **values**: different `maxAttempts` per channel; different `rateLimitForSeconds` windows per channel (verified via the event's `availableIn`)
- [x] Channel surfaced on event + log context (null in default mode); explicit-channel precedence honoured over `via()`
- [x] BC: legacy 2-param `rateLimitKey`, 0-param `maxAttempts`, and 5-param custom event class all keep working

Per-channel mode delivers each channel in its own send, so Laravel assigns a distinct notification id per channel (documented in the README).